### PR TITLE
Fix login link paths and clean font URLs

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Dashboard - DrayageDirect</title>
   <link rel="icon" href="favicon.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
   <style>
     :root {
       --bg: #f0f9ff;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DrayageDirect.io</title>
   <link rel="icon" href="favicon.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
   <style>
     :root {

--- a/login.html
+++ b/login.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login - DrayageDirect</title>
   <link rel="icon" href="favicon.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
   <style>
     :root {
       --bg: #f9fafb;
@@ -65,12 +65,12 @@
 <body>
   <div class="login-card">
     <h2>Login</h2>
-<form action="/drayagedirect/dashboard.html" method="GET">
+<form action="dashboard.html" method="GET">
       <input type="email" placeholder="Email" required />
       <input type="password" placeholder="Password" required />
       <button type="submit">Log In</button>
     </form>
-    <a href="/signup">Don't have an account? Sign up</a>
+    <a href="signup.html">Don't have an account? Sign up</a>
   </div>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sign Up - DrayageDirect</title>
   <link rel="icon" href="favicon.png" type="image/png" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
   <style>
     :root {
       --bg: #f9fafb;


### PR DESCRIPTION
## Summary
- fix login form and signup link path
- escape query parameter in Google Fonts link across pages

## Testing
- `tidy -q login.html`
- `tidy -q signup.html`
- `tidy -q index.html`
- `tidy -q dashboard.html`


------
https://chatgpt.com/codex/tasks/task_e_68439ab813fc832ca3fd6b61dc4e1ccd