### PR TITLE
fix(load-margin): super_admin permission short-circuit

### DIFF
--- a/pages/api/tenant/ar/index.js
+++ b/pages/api/tenant/ar/index.js
@@ -1,7 +1,7 @@
 import { requireTenantUser, getServiceClient } from '../../../../lib/tenant-api';
 import { parseCsvParam } from '../../../../lib/ar-filter-params';
 import { fetchLoadMarginInputs, computeLoadMargin } from '../../../../lib/load-margin';
-import { PERMISSIONS } from '../../../../lib/permissions';
+import { PERMISSIONS, hasPermission } from '../../../../lib/permissions';
 
 /**
  * GET /api/tenant/ar
@@ -290,13 +290,10 @@ export default async function handler(req, res) {
   }
 
   // ── Load Margin: attach margin object per row ─────────────────────────
-  // Gated on ACCOUNTS_RECEIVABLE | REPORTING | ALL — users without the
-  // permission receive rows without a margin object, and the margin filter
+  // Gated on ACCOUNTS_RECEIVABLE | REPORTING | super_admin — users without
+  // the permission receive rows without a margin object, and the margin filter
   // is treated as a no-op so they don't accidentally see empty results.
-  const canSeeMargin =
-    ctx.permissions.includes(PERMISSIONS.ACCOUNTS_RECEIVABLE) ||
-    ctx.permissions.includes(PERMISSIONS.REPORTING) ||
-    ctx.permissions.includes(PERMISSIONS.ALL);
+  const canSeeMargin = hasPermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.REPORTING]);
 
   if (canSeeMargin && scopedSets.length > 0) {
     try {

--- a/pages/api/tenant/ar/invoices/index.js
+++ b/pages/api/tenant/ar/invoices/index.js
@@ -4,7 +4,7 @@ import {
   getServiceClient,
 } from '../../../../../lib/tenant-api';
 import { logTenantAction, getClientIp } from '../../../../../lib/tenant-audit';
-import { PERMISSIONS } from '../../../../../lib/permissions';
+import { PERMISSIONS, hasPermission } from '../../../../../lib/permissions';
 import { assignInvoiceNumberBase } from '../../../../../lib/invoice-utils';
 import { computeInvoiceDueDate } from '../../../../../lib/ar-utils';
 import { parseCsvParam } from '../../../../../lib/ar-filter-params';
@@ -19,7 +19,7 @@ import { fetchLoadMarginInputs, computeLoadMargin } from '../../../../../lib/loa
 export default async function handler(req, res) {
   const ctx = await requireTenantUser(req, res);
   if (!ctx) return;
-  if (!requirePermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.ALL], res)) return;
+  if (!requirePermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE], res)) return;
 
   const svc = getServiceClient();
 
@@ -246,7 +246,10 @@ export default async function handler(req, res) {
     // ── Load Margin: attach margin object per invoice row ─────────────────
     // Invoices are load-level documents; collect distinct order IDs from
     // their nested charge_sets, compute margin once per order, then attach.
-    if (filtered.length > 0) {
+    // Gated on ACCOUNTS_RECEIVABLE | REPORTING | super_admin — consistent
+    // with loads list and AR endpoints.
+    const canSeeMargin = hasPermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.REPORTING]);
+    if (canSeeMargin && filtered.length > 0) {
       try {
         const { data: tenant, error: tErr } = await svc
           .from('tenants')
@@ -319,13 +322,15 @@ export default async function handler(req, res) {
     // ── Margin range filter ─────────────────────────────────────────────
     // Runs after the margin-attach block so inv.margin is populated.
     // Neutral-bucket rows (no revenue or no cost) are excluded from numeric ranges.
+    // Skip entirely when the caller lacks the margin-view permission — no rows
+    // have .margin attached, so filtering would produce an empty result set.
     const { margin_from, margin_to } = req.query;
     const marginFrom = margin_from !== '' && margin_from != null
       ? Number(margin_from) : null;
     const marginTo   = margin_to   !== '' && margin_to   != null
       ? Number(margin_to)   : null;
 
-    if (Number.isFinite(marginFrom) || Number.isFinite(marginTo)) {
+    if (canSeeMargin && (Number.isFinite(marginFrom) || Number.isFinite(marginTo))) {
       filtered = filtered.filter((inv) => {
         const m = inv.margin;
         if (!m || m.bucket === 'neutral') return false;

--- a/pages/api/tenant/loads/[id]/index.js
+++ b/pages/api/tenant/loads/[id]/index.js
@@ -4,7 +4,7 @@ import {
   getServiceClient,
 } from '../../../../../lib/tenant-api';
 import { logTenantAction, getClientIp } from '../../../../../lib/tenant-audit';
-import { PERMISSIONS } from '../../../../../lib/permissions';
+import { PERMISSIONS, hasPermission } from '../../../../../lib/permissions';
 import { fireFieldChangeTriggers, fireStatusChangeTriggers } from '../../../../../lib/email-dispatch';
 import { fetchLoadMarginInputs, computeLoadMargin } from '../../../../../lib/load-margin';
 
@@ -209,11 +209,7 @@ export default async function handler(req, res) {
     }
 
     // ── Margin attach (gated by ACCOUNTS_RECEIVABLE / REPORTING / ALL) ──
-    if (
-      ctx.permissions.includes(PERMISSIONS.ACCOUNTS_RECEIVABLE) ||
-      ctx.permissions.includes(PERMISSIONS.REPORTING) ||
-      ctx.permissions.includes(PERMISSIONS.ALL)
-    ) {
+    if (hasPermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.REPORTING])) {
       try {
         const { data: tenant, error: tErr } = await svc
           .from('tenants')

--- a/pages/api/tenant/loads/index.js
+++ b/pages/api/tenant/loads/index.js
@@ -4,7 +4,7 @@ import {
   getServiceClient,
 } from '../../../../lib/tenant-api';
 import { logTenantAction, getClientIp } from '../../../../lib/tenant-audit';
-import { PERMISSIONS } from '../../../../lib/permissions';
+import { PERMISSIONS, hasPermission } from '../../../../lib/permissions';
 import { buildRoutingEventsForTemplate } from '../../../../lib/routing-template-seed';
 import { computeKpiStats } from '../../../../lib/kpi-engine';
 import { findMatchingCharges, applyChargesToLoad } from '../../../../lib/tariff-engine';
@@ -286,14 +286,7 @@ export default async function handler(req, res) {
     // Attach margin per row for users with AR/reporting access.
     // Uses the full `data` set (before active_only filter) so every row in
     // visibleLoads already has .margin when it reaches the client.
-    if (
-      data.length > 0 &&
-      (
-        ctx.permissions.includes(PERMISSIONS.ACCOUNTS_RECEIVABLE) ||
-        ctx.permissions.includes(PERMISSIONS.REPORTING) ||
-        ctx.permissions.includes(PERMISSIONS.ALL)
-      )
-    ) {
+    if (data.length > 0 && hasPermission(ctx, [PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.REPORTING])) {
       try {
         const { data: tenant, error: tErr } = await svc
           .from('tenants')

--- a/pages/api/tenant/me/margin-thresholds.js
+++ b/pages/api/tenant/me/margin-thresholds.js
@@ -1,5 +1,5 @@
 import { requireTenantUser, requirePermission, getServiceClient } from '../../../../lib/tenant-api';
-import { PERMISSIONS } from '../../../../lib/permissions';
+import { PERMISSIONS, hasPermission } from '../../../../lib/permissions';
 
 export default async function handler(req, res) {
   const ctx = await requireTenantUser(req, res);
@@ -12,12 +12,7 @@ export default async function handler(req, res) {
 }
 
 async function handleGet(req, res, ctx) {
-  if (
-    !ctx.permissions.includes(PERMISSIONS.SETTINGS) &&
-    !ctx.permissions.includes(PERMISSIONS.ACCOUNTS_RECEIVABLE) &&
-    !ctx.permissions.includes(PERMISSIONS.REPORTING) &&
-    !ctx.permissions.includes(PERMISSIONS.ALL)
-  ) {
+  if (!hasPermission(ctx, [PERMISSIONS.SETTINGS, PERMISSIONS.ACCOUNTS_RECEIVABLE, PERMISSIONS.REPORTING])) {
     return res.status(403).json({ error: 'Forbidden' });
   }
 
@@ -41,8 +36,8 @@ async function handleGet(req, res, ctx) {
 }
 
 async function handlePut(req, res, ctx) {
-  // Permission check: only SETTINGS or ALL can write
-  if (!requirePermission(ctx, [PERMISSIONS.SETTINGS, PERMISSIONS.ALL], res)) return;
+  // Permission check: only SETTINGS (or super_admin / 'all') can write
+  if (!requirePermission(ctx, [PERMISSIONS.SETTINGS], res)) return;
 
   const { red_threshold, yellow_threshold, include_dry_runs } = req.body ?? {};
 


### PR DESCRIPTION
Live gate walk (post-merge of #2) caught this:

Users with `role === 'super_admin'` have an empty `permissions` array — they bypass permission checks via role, not individual permissions. The Load Margin endpoint checks used raw `ctx.permissions.includes(PERMISSIONS.X)` which doesn't short-circuit on role. Result: the super admin was 403'd on every margin surface.

Fix: replace 5 endpoint checks with `hasPermission(ctx, [...])` from `lib/permissions.js`, which handles both the super_admin role bypass and the 'all' permission bypass.

Files:
- pages/api/tenant/me/margin-thresholds.js (GET + PUT)
- pages/api/tenant/loads/[id]/index.js
- pages/api/tenant/loads/index.js
- pages/api/tenant/ar/index.js
- pages/api/tenant/ar/invoices/index.js

Tests: 39/39 green (unchanged).