### PR TITLE
feat(driver-tracking): driver mobile move-tracking (FU-085)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 
+# Server-side Google Maps (separate from NEXT_PUBLIC_GOOGLE_MAPS_API_KEY).
+# The public key is domain-restricted for client-side use; the server key
+# is unrestricted (server IP isn't predictable) and reserved for
+# Distance Matrix REST calls from server-side ETA recompute paths.
+# Required by lib/google-maps/server-distance.js (FU-085 driver tracking).
+GOOGLE_MAPS_SERVER_API_KEY=
+
 # Supabase (replace with your project credentials from supabase.com)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
@@ -14,6 +21,14 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 # Admin Dashboard
 ADMIN_JWT_SECRET=
+
+# Driver mobile app JWT signing key (FU-085 driver tracking).
+# Generate a strong random value, e.g.:
+#   node -e "console.log(require('crypto').randomBytes(64).toString('base64'))"
+# Required by lib/driver-auth/utils.js for sign/verify of driver session
+# tokens (30-day TTL). Bumping drivers.session_min_iat invalidates old
+# tokens, but the secret itself should rotate rarely.
+DRIVER_JWT_SECRET=
 
 # SendGrid
 SENDGRID_API_KEY=

--- a/components/dispatcher/planner/MoveCell.jsx
+++ b/components/dispatcher/planner/MoveCell.jsx
@@ -1,5 +1,10 @@
+import { useEffect, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { Check, X } from 'lucide-react';
+import {
+  fmtRelativeETA, fmtAbsoluteETA, fmtOnSiteDuration,
+  freshnessColor, freshnessColorClass,
+} from '../../../lib/dispatcher/tracking-display.js';
 
 const STATUS_BG = {
   unassigned: 'bg-gray-100 dark:bg-gray-800',
@@ -34,6 +39,55 @@ function fmtApt(iso) {
   } catch {
     return null;
   }
+}
+
+function TrackingLine({ move, events }) {
+  // tick every 1s when on_site to refresh the counter
+  const [, force] = useState(0);
+  useEffect(() => {
+    if (move.tracking_status !== 'on_site') return;
+    const t = setInterval(() => force((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [move.tracking_status]);
+
+  const nextPending = events.find((e) => e.event_status === 'pending');
+  const arrived = events.find((e) => e.event_status === 'arrived');
+  const dot = freshnessColorClass(freshnessColor(move.last_ping_at));
+
+  if (move.tracking_status === 'in_transit') {
+    if (!nextPending) return null;
+    return (
+      <div className="px-2 pb-1 text-[10px] flex items-center gap-1">
+        <span className={`w-1.5 h-1.5 rounded-full ${dot}`} title={`Last ping ${move.last_ping_at || 'unknown'}`} />
+        <span className="text-blue-700 dark:text-blue-400">▶</span>
+        <span className="text-gray-700 dark:text-gray-300">
+          ETA {fmtAbsoluteETA(nextPending.eta_arrival_at)} · {fmtRelativeETA(nextPending.eta_arrival_at)}
+        </span>
+      </div>
+    );
+  }
+  if (move.tracking_status === 'on_site') {
+    if (!arrived) return null;
+    return (
+      <div className="px-2 pb-1 text-[10px] flex items-center gap-1">
+        <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />
+        <span>📍</span>
+        <span className="text-green-700 dark:text-green-400">On-site {fmtOnSiteDuration(arrived.arrived_at)}</span>
+      </div>
+    );
+  }
+  if (move.tracking_status === 'paused') {
+    const pausedFor = move.last_ping_at
+      ? Math.round((Date.now() - new Date(move.last_ping_at).getTime()) / 60000)
+      : null;
+    return (
+      <div className="px-2 pb-1 text-[10px] flex items-center gap-1 text-amber-700 dark:text-amber-400">
+        <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />
+        <span>⏸ Paused {pausedFor != null ? `${pausedFor}m` : ''}</span>
+      </div>
+    );
+  }
+  return null;
 }
 
 export default function MoveCell({ move, onClickPreview, onOpenLoad, onDispatch, onUnassign }) {
@@ -126,6 +180,10 @@ export default function MoveCell({ move, onClickPreview, onOpenLoad, onDispatch,
         <div className="px-2 pb-1 text-[10px] text-gray-500 dark:text-gray-500">
           Assigned: {fmtApt(move.assigned_at)}
         </div>
+      )}
+
+      {move.tracking_status && move.tracking_status !== 'idle' && move.tracking_status !== 'completed' && (
+        <TrackingLine move={move} events={move.events || []} />
       )}
 
       <div className="flex-1 px-2 pb-2 space-y-1">

--- a/components/drivers/DriverModal.js
+++ b/components/drivers/DriverModal.js
@@ -138,7 +138,53 @@ export default function DriverModal({ isOpen, onClose, onSuccess, editing = null
             <DriverPreferencesTab form={form} update={update} />
           )}
           {activeTab === 'mobile' && (
-            <DriverMobilePermissionsTab form={form} update={update} />
+            <>
+              <DriverMobilePermissionsTab form={form} update={update} />
+              {/* Driver app access — only shown for existing drivers, not on Add Driver */}
+              {editing?.id && (
+                <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+                  <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Driver app access</h3>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        if (!confirm(`Reset password for ${editing.name}? You'll need to relay the new temporary password to them.`)) return;
+                        const res = await fetch(`/api/tenant/drivers/${editing.id}/reset-password`, {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({}),
+                        });
+                        const data = await res.json();
+                        if (!res.ok) {
+                          alert(`Reset failed: ${data.error || res.status}`);
+                          return;
+                        }
+                        alert(`New temporary password: ${data.temp_password}\n\nThe driver will be required to change it on next login.`);
+                      }}
+                      className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                      Reset password
+                    </button>
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        if (!confirm(`Kill ${editing.name}'s active session? They'll be signed out and need to log in again.`)) return;
+                        const res = await fetch(`/api/tenant/drivers/${editing.id}/kill-session`, { method: 'POST' });
+                        if (res.ok) {
+                          alert('Session killed.');
+                        } else {
+                          const data = await res.json().catch(() => ({}));
+                          alert(`Kill failed: ${data.error || res.status}`);
+                        }
+                      }}
+                      className="px-3 py-1.5 text-sm rounded border border-red-300 dark:border-red-700 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950"
+                    >
+                      Kill session
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
           )}
           {activeTab === 'notes' && <DriverNotesTab form={form} update={update} />}
         </div>

--- a/components/drivers/tabs/DriverMobilePermissionsTab.js
+++ b/components/drivers/tabs/DriverMobilePermissionsTab.js
@@ -28,7 +28,6 @@ const OTHER_PERMISSIONS = [
   { key: 'require_geofence_clock_in', label: "Require driver to clock into geofenced location first" },
   { key: 'allow_view_documents', label: 'Allow driver to view document types in General Settings' },
   { key: 'allow_add_weight_pieces', label: 'Allow to add weight and pieces for commodities' },
-  { key: 'location_tracking_enabled', label: 'Track driver location during moves' },
 ];
 
 const PROFILE_PERMISSIONS = [
@@ -87,6 +86,26 @@ export default function DriverMobilePermissionsTab({ form, update }) {
         values={perms}
         onChange={setPerms}
       />
+
+      {/* Location tracking — top-level driver column (NOT nested in mobile_permissions JSONB).
+          Per migration 102, drivers.location_tracking_enabled is a top-level boolean read by
+          requireDriver middleware + 3-gate helper. Keep this toggle outside the PermissionGroup
+          iterators so it routes through update('location_tracking_enabled', value) directly. */}
+      <div>
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-slate-100 mb-3">Location tracking</h4>
+        <div className="space-y-2 bg-gray-50 dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-lg p-4">
+          <Checkbox
+            checked={form?.location_tracking_enabled !== false}
+            onChange={(v) => update('location_tracking_enabled', v)}
+            label="Track driver location during moves"
+          />
+          <p className="text-xs text-gray-500 dark:text-slate-400 ml-6">
+            When enabled and the tenant feature is on, the driver mobile app reports GPS pings during active moves.
+            Driver consent on first login is still required.
+          </p>
+        </div>
+      </div>
+
       {(form?.tracking_consented_at || form?.tracking_revoked_at) && (
         <div className="text-xs text-gray-600 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700 pt-3">
           {form.tracking_consented_at && (

--- a/components/drivers/tabs/DriverMobilePermissionsTab.js
+++ b/components/drivers/tabs/DriverMobilePermissionsTab.js
@@ -28,6 +28,7 @@ const OTHER_PERMISSIONS = [
   { key: 'require_geofence_clock_in', label: "Require driver to clock into geofenced location first" },
   { key: 'allow_view_documents', label: 'Allow driver to view document types in General Settings' },
   { key: 'allow_add_weight_pieces', label: 'Allow to add weight and pieces for commodities' },
+  { key: 'location_tracking_enabled', label: 'Track driver location during moves' },
 ];
 
 const PROFILE_PERMISSIONS = [
@@ -86,6 +87,18 @@ export default function DriverMobilePermissionsTab({ form, update }) {
         values={perms}
         onChange={setPerms}
       />
+      {(form?.tracking_consented_at || form?.tracking_revoked_at) && (
+        <div className="text-xs text-gray-600 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700 pt-3">
+          {form.tracking_consented_at && (
+            <div>Last consented: {new Date(form.tracking_consented_at).toLocaleString()} (v{form.tracking_consent_version || '?'})</div>
+          )}
+          {form.tracking_revoked_at && (
+            <div className="text-amber-700 dark:text-amber-400">
+              Revoked: {new Date(form.tracking_revoked_at).toLocaleString()}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/loads/routing/EventRow.js
+++ b/components/loads/routing/EventRow.js
@@ -7,6 +7,7 @@ import StatusButton from './StatusButton';
 import { EVENT_LABELS } from '../../../lib/routing-template-seed';
 import DryRunList from './DryRunList';
 import DryRunSlideOver from './DryRunSlideOver';
+import OverrideDriverModal from '../tracking/OverrideDriverModal';
 
 const DRY_RUN_ELIGIBLE_EVENTS = new Set(['pull', 'pickup', 'deliver', 'return', 'drop', 'hook']);
 
@@ -102,6 +103,79 @@ function DistanceDisplay({ event, legMetrics, onOverride, onResetToAuto }) {
 
 function labelFor(eventType) {
   return EVENT_LABELS[eventType] || (eventType || '').replace(/^./, (c) => c.toUpperCase());
+}
+
+/**
+ * HistoryBadges — shows a green "driver" badge when the most recent
+ * history entry for a given event+field came from the driver app, or an
+ * amber "override" badge when a dispatcher overrode a driver timestamp.
+ *
+ * Fetches /api/tenant/loads/[loadId]/tracking once on mount (per-row,
+ * v1 acceptable per plan). Click on the driver badge opens the override
+ * modal.
+ */
+function HistoryBadges({ eventId, loadId, fieldName, currentValue }) {
+  const [latestRow, setLatestRow] = useState(null);
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (!currentValue) { setLatestRow(null); return; }
+    let cancelled = false;
+    (async () => {
+      const res = await fetch(`/api/tenant/loads/${loadId}/tracking`);
+      if (!res.ok || cancelled) return;
+      const data = await res.json();
+      const targetStatus = fieldName === 'arrived_at' ? 'arrived' : 'departed';
+      const eventHistory = (data.events_history || [])
+        .filter((h) => h.event_id === eventId && h.to_status === targetStatus)
+        .sort((a, b) => new Date(b.transitioned_at) - new Date(a.transitioned_at));
+      if (!cancelled) setLatestRow(eventHistory[0] ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, [eventId, loadId, fieldName, currentValue]);
+
+  if (!latestRow) return null;
+  const ctx = latestRow.actor_context || {};
+  const wasDriver = ctx.source === 'driver_app';
+  const wasOverride = ctx.overrode_driver === true;
+
+  return (
+    <>
+      {wasDriver && (
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          className="ml-1 inline-flex items-center text-[10px] px-1 py-0.5 rounded bg-green-100 dark:bg-green-950 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900"
+          title={`Driver tapped at ${new Date(latestRow.transitioned_at).toLocaleString()}${
+            ctx.gps_distance_at_arrival_m != null
+              ? ` (GPS within ${(ctx.gps_distance_at_arrival_m / 1609).toFixed(2)} mi)`
+              : ''
+          }. Click to override.`}
+        >
+          📱 driver
+        </button>
+      )}
+      {wasOverride && (
+        <span
+          className="ml-1 inline-flex items-center text-[10px] px-1 py-0.5 rounded bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300"
+          title={`Override${ctx.original_driver_timestamp ? ` (driver had: ${new Date(ctx.original_driver_timestamp).toLocaleString()})` : ''}${ctx.reason ? `\nReason: ${ctx.reason}` : ''}`}
+        >
+          🔄 override
+        </span>
+      )}
+      {showModal && (
+        <OverrideDriverModal
+          event={{ id: eventId, location_name: latestRow.event?.location_name }}
+          driverTimestamp={latestRow.transitioned_at}
+          driverGpsDistanceM={ctx.gps_distance_at_arrival_m}
+          fieldName={fieldName}
+          loadId={loadId}
+          onClose={() => setShowModal(false)}
+          onSaved={() => window.location.reload()}
+        />
+      )}
+    </>
+  );
 }
 
 /**
@@ -320,13 +394,23 @@ export default function EventRow({
             <span className="text-xs font-medium text-gray-500 dark:text-slate-400 w-20 shrink-0">
               {isDropEvent ? 'Dropped' : 'Arrival'}
             </span>
-            <StatusButton
-              label={isDropEvent ? 'Dropped' : 'Arrived'}
-              value={event.arrived_at}
-              onChange={handleArrived}
-              use24h={use24h}
-              disabled={loadCompleted || !moveStarted}
-            />
+            <div className="flex items-center flex-wrap gap-1">
+              <StatusButton
+                label={isDropEvent ? 'Dropped' : 'Arrived'}
+                value={event.arrived_at}
+                onChange={handleArrived}
+                use24h={use24h}
+                disabled={loadCompleted || !moveStarted}
+              />
+              {orderId && (
+                <HistoryBadges
+                  eventId={event.id}
+                  loadId={orderId}
+                  fieldName="arrived_at"
+                  currentValue={event.arrived_at}
+                />
+              )}
+            </div>
           </div>
 
           {/* Departure row — hidden for Drop events (auto-set to match arrival) */}
@@ -335,7 +419,17 @@ export default function EventRow({
               <div className="border-t border-gray-50 dark:border-slate-800" />
               <div className="flex items-center px-4 py-2 gap-3">
                 <span className="text-xs font-medium text-gray-500 dark:text-slate-400 w-20 shrink-0">Departure</span>
-                <StatusButton label="Departed" value={event.departed_at} onChange={handleDeparted} use24h={use24h} disabled={loadCompleted || !moveStarted} />
+                <div className="flex items-center flex-wrap gap-1">
+                  <StatusButton label="Departed" value={event.departed_at} onChange={handleDeparted} use24h={use24h} disabled={loadCompleted || !moveStarted} />
+                  {orderId && (
+                    <HistoryBadges
+                      eventId={event.id}
+                      loadId={orderId}
+                      fieldName="departed_at"
+                      currentValue={event.departed_at}
+                    />
+                  )}
+                </div>
               </div>
             </>
           )}

--- a/components/loads/tabs/TrackingTab.js
+++ b/components/loads/tabs/TrackingTab.js
@@ -2,6 +2,12 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { MapPin, Clock, Truck, Navigation, Radio, Wifi, WifiOff, CircleDot, ArrowRight, Check } from 'lucide-react';
 import { loadGoogleMaps } from '../../../lib/google-maps-loader';
 import { EVENT_LABELS } from '../../../lib/routing-template-seed';
+import EventTimeline from '../tracking/EventTimeline.js';
+import BreadcrumbMap from '../tracking/BreadcrumbMap.js';
+import ActivityLog from '../tracking/ActivityLog.js';
+import {
+  fmtAbsoluteETA, fmtRelativeETA, freshnessColor, freshnessColorClass,
+} from '../../../lib/dispatcher/tracking-display.js';
 
 const SOURCE_LABELS = {
   eld: { label: 'ELD', icon: Radio, color: 'text-green-600 dark:text-green-400', bg: 'bg-green-100 dark:bg-green-950/40' },
@@ -40,6 +46,10 @@ export default function TrackingTab({ load }) {
   const [driverLocation, setDriverLocation] = useState(null);
   const [locations, setLocations] = useState({});
   const [selectedEventId, setSelectedEventId] = useState(null);
+  // New: per-move live tracking state (Task 33 endpoint fields)
+  const [pings, setPings] = useState([]);
+  const [eventsHistory, setEventsHistory] = useState([]);
+  const [movesHistory, setMovesHistory] = useState([]);
 
   const driverName = load.driver
     ? `${load.driver.first_name || ''} ${load.driver.last_name || ''}`.trim() || load.driver.name
@@ -59,6 +69,10 @@ export default function TrackingTab({ load }) {
           setLocations(data.locations || {});
           setLastPing(data.last_ping || null);
           setGpsSource(data.gps_source || null);
+          // New: per-move live tracking fields
+          setPings(data.pings || []);
+          setEventsHistory(data.events_history || []);
+          setMovesHistory(data.moves_history || []);
           if (data.last_ping) {
             setDriverLocation({
               lat: parseFloat(data.last_ping.latitude),
@@ -78,6 +92,18 @@ export default function TrackingTab({ load }) {
     if (!eventsByMove[evt.move_id]) eventsByMove[evt.move_id] = [];
     eventsByMove[evt.move_id].push(evt);
   }
+
+  // Build enriched moves for the Live Tracking section (moves extended with their events array)
+  const movesById = (moves || []).reduce((acc, m) => {
+    acc[m.id] = { ...m, events: [] };
+    return acc;
+  }, {});
+  for (const e of routingEvents || []) {
+    if (movesById[e.move_id]) {
+      movesById[e.move_id].events.push(e);
+    }
+  }
+  const enrichedMoves = Object.values(movesById);
 
   // Init map
   useEffect(() => {
@@ -226,6 +252,67 @@ export default function TrackingTab({ load }) {
 
   return (
     <div className="space-y-4">
+      {/* New: per-move Live Tracking section (Task 37) — shown above legacy UI when any move is actively tracked */}
+      {enrichedMoves.length > 0 && enrichedMoves.some((m) => m.tracking_status && m.tracking_status !== 'idle') && (
+        <div className="space-y-4 mb-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Live Tracking</h2>
+          {enrichedMoves
+            .filter((m) => m.tracking_status && m.tracking_status !== 'idle')
+            .map((m) => {
+              const driver = m.driver || {};
+              const dot = freshnessColorClass(freshnessColor(m.last_ping_at));
+              const nextPending = (m.events || []).find((e) => e.event_status === 'pending');
+              const arrived = (m.events || []).find((e) => e.event_status === 'arrived');
+              const movePings = (pings || []).filter((p) => p.move_id === m.id);
+              return (
+                <div key={m.id} className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+                  <div className="p-3 border-b border-gray-200 dark:border-gray-700">
+                    <div className="flex items-center gap-2 text-sm flex-wrap">
+                      <span className={`w-2 h-2 rounded-full ${dot}`} />
+                      <span className="font-medium text-gray-900 dark:text-gray-100">
+                        Driver: {driver.name || '—'}
+                      </span>
+                      <span className="text-gray-500 dark:text-gray-400">·</span>
+                      <span className="text-gray-700 dark:text-gray-300 capitalize">
+                        {m.tracking_status?.replace('_', ' ') || 'idle'}
+                      </span>
+                      {m.tracking_status === 'in_transit' && nextPending?.eta_arrival_at && (
+                        <>
+                          <span className="text-gray-500 dark:text-gray-400">·</span>
+                          <span className="text-blue-700 dark:text-blue-400">
+                            ETA {fmtAbsoluteETA(nextPending.eta_arrival_at)} ({fmtRelativeETA(nextPending.eta_arrival_at)}) → {nextPending.location_name}
+                          </span>
+                        </>
+                      )}
+                      {m.tracking_status === 'on_site' && arrived && (
+                        <>
+                          <span className="text-gray-500 dark:text-gray-400">·</span>
+                          <span className="text-green-700 dark:text-green-400">📍 {arrived.location_name}</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-3">
+                    <BreadcrumbMap move={m} pings={movePings} />
+                    <EventTimeline move={m} />
+                  </div>
+                </div>
+              );
+            })}
+          {/* Activity log below all moves */}
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+            <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Driver Activity Log</h3>
+            <ActivityLog
+              events_history={eventsHistory}
+              moves_history={movesHistory}
+              events={routingEvents}
+              moves={enrichedMoves}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Legacy migration-036-era UI — preserved below */}
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/components/loads/tracking/ActivityLog.js
+++ b/components/loads/tracking/ActivityLog.js
@@ -1,0 +1,50 @@
+// components/loads/tracking/ActivityLog.js
+const SOURCE_CHIP = {
+  driver_app: 'bg-green-100 dark:bg-green-950 text-green-800 dark:text-green-300',
+  dispatcher_ui: 'bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-300',
+  system: 'bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300',
+  geofence: 'bg-purple-100 dark:bg-purple-950 text-purple-800 dark:text-purple-300',
+};
+
+function chipFor(actor_type, actor_context) {
+  const source = actor_context?.source ?? actor_type;
+  return SOURCE_CHIP[source] || 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300';
+}
+
+export default function ActivityLog({ events_history, moves_history, events, moves }) {
+  // Merge + sort
+  const eventsById = Object.fromEntries((events || []).map((e) => [e.id, e]));
+  const movesById = Object.fromEntries((moves || []).map((m) => [m.id, m]));
+  const combined = [
+    ...(events_history || []).map((h) => ({
+      kind: 'event', at: h.transitioned_at, h,
+      label: `${eventsById[h.event_id]?.location_name || 'Event'}: ${h.from_status || '∅'} → ${h.to_status}`,
+    })),
+    ...(moves_history || []).map((h) => ({
+      kind: 'move', at: h.transitioned_at, h,
+      label: `Move ${(movesById[h.move_id]?.id || '').slice(0, 8)}: ${h.from_status || '∅'} → ${h.to_status}`,
+    })),
+  ].sort((a, b) => new Date(b.at) - new Date(a.at));
+
+  if (combined.length === 0) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No activity yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {combined.map((entry, idx) => {
+        const ts = new Date(entry.at).toLocaleString();
+        return (
+          <li key={`${entry.kind}-${entry.h.id}-${idx}`} className="text-sm flex items-baseline gap-2">
+            <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] uppercase font-medium ${chipFor(entry.h.actor_type, entry.h.actor_context)}`}>
+              {entry.h.actor_context?.source ?? entry.h.actor_type}
+            </span>
+            <span className="text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">{ts}</span>
+            <span className="text-gray-800 dark:text-gray-200">{entry.label}</span>
+            {entry.h.note && <span className="text-gray-500 dark:text-gray-400 text-xs italic">— {entry.h.note}</span>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/loads/tracking/BreadcrumbMap.js
+++ b/components/loads/tracking/BreadcrumbMap.js
@@ -1,0 +1,80 @@
+// components/loads/tracking/BreadcrumbMap.js
+import { useEffect, useRef } from 'react';
+import { loadGoogleMaps } from '../../../lib/google-maps-loader.js';
+
+export default function BreadcrumbMap({ move, pings }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let map = null;
+    (async () => {
+      try {
+        const google = await loadGoogleMaps();
+        if (cancelled || !ref.current) return;
+
+        // Use the ping data for centering since drivers.last_* is per-driver,
+        // not per-move. The breadcrumb itself is the source of truth for
+        // "where this move's driver has been".
+        const latestPing = (pings && pings.length > 0)
+          ? [...pings].sort((a, b) => new Date(b.recorded_at) - new Date(a.recorded_at))[0]
+          : null;
+        const center = latestPing
+          ? { lat: parseFloat(latestPing.latitude), lng: parseFloat(latestPing.longitude) }
+          : { lat: 37.5, lng: -122.0 };
+
+        map = new google.maps.Map(ref.current, {
+          center, zoom: 10,
+          mapTypeControl: false, streetViewControl: false, fullscreenControl: false,
+        });
+
+        const bounds = new google.maps.LatLngBounds();
+
+        // Breadcrumb polyline from pings (oldest → newest).
+        // Pings come back DESC from the endpoint; reverse so the polyline
+        // draws in chronological order.
+        if (pings && pings.length > 0) {
+          const path = [...pings]
+            .sort((a, b) => new Date(a.recorded_at) - new Date(b.recorded_at))
+            .map((p) => ({ lat: parseFloat(p.latitude), lng: parseFloat(p.longitude) }));
+          new google.maps.Polyline({
+            path,
+            geodesic: true,
+            strokeColor: '#2563eb',
+            strokeOpacity: 0.8,
+            strokeWeight: 3,
+            map,
+          });
+          for (const ll of path) bounds.extend(ll);
+        }
+
+        // Driver pulse marker — most recent ping
+        if (latestPing) {
+          const driverPos = {
+            lat: parseFloat(latestPing.latitude),
+            lng: parseFloat(latestPing.longitude),
+          };
+          new google.maps.Marker({
+            map, position: driverPos,
+            icon: {
+              path: google.maps.SymbolPath.CIRCLE,
+              scale: 8, fillColor: '#2563eb', fillOpacity: 1,
+              strokeColor: '#fff', strokeWeight: 2,
+            },
+            title: 'Driver',
+          });
+          bounds.extend(driverPos);
+        }
+
+        if (!bounds.isEmpty()) map.fitBounds(bounds);
+      } catch (err) {
+        console.error('BreadcrumbMap load error:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [move?.id, pings?.length]);
+
+  return (
+    <div ref={ref} className="w-full h-[400px] rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800" />
+  );
+}

--- a/components/loads/tracking/EventTimeline.js
+++ b/components/loads/tracking/EventTimeline.js
@@ -1,0 +1,43 @@
+// components/loads/tracking/EventTimeline.js
+import {
+  fmtAbsoluteETA, fmtRelativeETA, fmtOnSiteDuration,
+} from '../../../lib/dispatcher/tracking-display.js';
+
+const ICONS = {
+  pending: '⏳', arrived: '📍', departed: '✓', skipped: '⊝',
+};
+
+export default function EventTimeline({ move }) {
+  const events = move.events || [];
+  return (
+    <ol className="space-y-2">
+      {events.map((e, idx) => {
+        const isCurrent = e.event_status === 'arrived';
+        const isPending = e.event_status === 'pending';
+        const tone =
+          e.event_status === 'departed' ? 'text-gray-700 dark:text-gray-300' :
+          isCurrent ? 'text-green-800 dark:text-green-200 font-semibold' :
+          isPending ? 'text-blue-700 dark:text-blue-400' :
+          'text-gray-500 dark:text-gray-500 line-through';
+        return (
+          <li key={e.id} className="text-sm">
+            <div className={tone}>
+              {ICONS[e.event_status] || '•'} {e.location_name || `Event ${idx + 1}`}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 ml-5">
+              {e.scheduled_at && <>Apt {new Date(e.scheduled_at).toLocaleString()}</>}
+              {e.arrived_at && <> · Arrived {new Date(e.arrived_at).toLocaleTimeString()}</>}
+              {e.departed_at && <> · Departed {new Date(e.departed_at).toLocaleTimeString()}</>}
+              {isCurrent && !e.departed_at && (
+                <> · On-site {fmtOnSiteDuration(e.arrived_at)}</>
+              )}
+              {isPending && e.eta_arrival_at && (
+                <> · ETA {fmtAbsoluteETA(e.eta_arrival_at)} ({fmtRelativeETA(e.eta_arrival_at)})</>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/components/loads/tracking/OverrideDriverModal.js
+++ b/components/loads/tracking/OverrideDriverModal.js
@@ -1,0 +1,91 @@
+// components/loads/tracking/OverrideDriverModal.js
+import { useState } from 'react';
+
+export default function OverrideDriverModal({
+  event,
+  driverTimestamp,
+  driverGpsDistanceM,
+  fieldName,    // 'arrived_at' or 'departed_at'
+  loadId,
+  onClose,
+  onSaved,
+}) {
+  const [override, setOverride] = useState(driverTimestamp);
+  const [reason, setReason] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const toStatus = fieldName === 'arrived_at' ? 'arrived' : 'departed';
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/tenant/loads/${loadId}/routing/events/${event.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dispatcher_override_driver: true,
+          to_status: toStatus,
+          override_timestamp: override,
+          reason,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.detail || data.error || `HTTP ${res.status}`);
+        return;
+      }
+      onSaved?.(data);
+      onClose?.();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 border border-gray-200 dark:border-gray-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Override Driver Timestamp</h2>
+        <div className="mt-3 space-y-2 text-sm">
+          <div className="text-gray-700 dark:text-gray-300">
+            Event: <span className="font-medium">{toStatus} at {event.location_name || 'this location'}</span>
+          </div>
+          <div className="text-gray-600 dark:text-gray-400">
+            Driver tapped: {driverTimestamp ? new Date(driverTimestamp).toLocaleString() : '—'}
+            {driverGpsDistanceM != null && (
+              <> (GPS within {(driverGpsDistanceM / 1609).toFixed(2)} mi)</>
+            )}
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          <label className="block text-sm">
+            Override to:
+            <input
+              type="datetime-local"
+              value={override ? override.slice(0, 16) : ''}
+              onChange={(e) => setOverride(e.target.value ? new Date(e.target.value).toISOString() : null)}
+              className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+          </label>
+          <label className="block text-sm">
+            Reason (optional):
+            <textarea
+              value={reason} onChange={(e) => setReason(e.target.value)} rows={2}
+              className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+          </label>
+        </div>
+        {error && <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>}
+        <div className="mt-4 flex justify-end gap-2">
+          <button onClick={onClose} className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300">
+            Cancel
+          </button>
+          <button onClick={handleSave} disabled={saving} className="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50">
+            {saving ? 'Saving\u2026' : 'Override and lock'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-04-24-driver-move-tracking.md
+++ b/docs/superpowers/plans/2026-04-24-driver-move-tracking.md
@@ -67,12 +67,13 @@
 - `pages/driver/settings.js`
 - `pages/driver/_components/ConsentScreen.js`
 
-**Dispatcher components:**
-- `components/loads/tabs/TrackingTab.js`
+**Dispatcher components (new sub-components for the existing TrackingTab):**
 - `components/loads/tracking/BreadcrumbMap.js`
 - `components/loads/tracking/EventTimeline.js`
 - `components/loads/tracking/ActivityLog.js`
 - `components/loads/tracking/OverrideDriverModal.js`
+
+(`components/loads/tabs/TrackingTab.js` is *modified*, not new — already exists from migration 036 era. Listed in Modified files below.)
 
 **Migrations:**
 - `supabase/migrations/102_driver_move_tracking.sql`
@@ -92,17 +93,25 @@
 ### Modified files
 
 - `lib/routing/event-status-transition.js` — call `fireRoutingEventTriggers` after timestamp side-effects (FU-080)
-- `pages/api/tenant/dispatcher/planner/index.js` — extend SELECT for tracking columns
+- `pages/api/tenant/dispatcher/planner/index.js` — extend SELECT for tracking columns (`tracking_status`, `last_ping_at`, `session_started_at`, `ping_count` — NOT `current_lat/lng`; those come from joined `drivers.last_latitude/last_longitude`)
 - `hooks/useDriverPlanner.js` — `UPDATE_TRACKING` reducer action, payload pre-filter
-- `components/dispatcher/planner/MoveCell.jsx` — tracking line, freshness dot
+- `components/dispatcher/planner/MoveCell.jsx` — tracking line, freshness dot (reads driver-level `last_latitude/last_longitude/last_location_at` for current pos)
 - `pages/api/tenant/loads/[id]/routing/events/[eventId].js` — accept `dispatcher_override_driver`, route through transition helper
 - `components/loads/routing/EventRow.js` — driver-tap + override badges
-- `components/loads/LoadDetail.js` (or similar) — wire Tracking tab into the lazy-loaded tabs array
+- **`pages/api/tenant/loads/[id]/tracking.js`** (already exists from migration 036 era) — extend with tracking_status + ETA + activity log (don't replace)
+- **`components/loads/tabs/TrackingTab.js`** (already exists) — extend with breadcrumb polyline + ETA display + activity log (don't replace)
 - `pages/api/tenant/drivers/index.js` — accept `initial_password`, hash, return temp on auto-gen
 - `pages/api/tenant/drivers/[id]/index.js` — accept `location_tracking_enabled` in PUT
 - `components/drivers/DriverModal.js` (Mobile Permissions tab) — `location_tracking_enabled` toggle + reset-password + kill-session buttons + last-consented status
 - `pages/settings/drivers.js` (existing or create new) — `move_tracking` master toggle card
 - `vercel.json` — cron entries for stale-ping-pause + breadcrumb-retention
+
+### Re-used from migration 036 (existing scaffolding, no new schema)
+
+- `driver_location_pings` table — extended via Task 1 with `move_id` + `battery_pct` columns. All ping inserts/reads go through this table (NOT a new `move_position_snapshots` table).
+- `drivers.last_latitude`, `drivers.last_longitude`, `drivers.last_location_at`, `drivers.last_speed_mph`, `drivers.last_heading`, `drivers.last_location_source` — denormalized "current location"; updated on every ping. Read by MoveCell + Tracking tab + planner.
+- `geofence_events` table — already shipped, used natively by Phase 2 geofence spec (out of scope for this plan).
+- `drive_segments` table — already shipped, separate concept from move-tracking. Out of scope.
 
 ### Convention compliance per PR
 
@@ -119,20 +128,60 @@
 
 PRs 2–7 all depend on PR 1. Deliverables: migration 102 (schema only — applied separately by user), three new lib modules, one helper extension (FU-080), unit tests.
 
+### ⚠️ Schema reconciliation note (added 2026-04-24 mid-execution)
+
+During Task 1 review, an exploration miss surfaced: **migration 036** (already shipped) had laid scaffolding tables — `driver_location_pings`, `geofence_events`, `drive_segments` — plus columns `drivers.last_latitude/last_longitude/last_location_at/last_speed_mph/last_heading/last_location_source/eld_provider/eld_device_id/eld_connected`. These tables sit empty (no writers) but the shape is ready. There's also already a `pages/api/tenant/loads/[id]/tracking.js` and `components/loads/tabs/TrackingTab.js` reading from them.
+
+The plan was reworked to **reuse the existing scaffolding** instead of creating parallel infrastructure. Concrete deltas from the original plan:
+
+| Original plan | Reconciled approach | Affected tasks |
+|---|---|---|
+| New table `move_position_snapshots` for GPS pings | **Extend `driver_location_pings`** with `move_id` + `battery_pct` columns; reuse existing source attribution + RLS + lat/lng CHECK constraints | Task 1 (migration), Task 6 (driver-action), Task 23 (ping), Task 33 (tracking endpoint), Task 35 (BreadcrumbMap) |
+| `order_container_moves.current_lat/current_lng` for "where is driver now" | **Read `drivers.last_latitude/last_longitude`** from migration 036; write through that column on every ping. A driver only works one in_transit/on_site move at a time, so per-driver denorm is sufficient. | Task 6 (driver-action), Task 17 (today.js), Task 23 (ping), Task 30 (planner SELECT), Task 32 (MoveCell tracking line) |
+| `order_container_moves.last_ping_at` (kept) | **Kept** — staleness-detection without join. Cron filters in_transit moves where `last_ping_at < now() - 10min`. | Task 1 (migration), Task 42 (cron) |
+| Create new `pages/api/tenant/loads/[id]/tracking.js` | **Extend the existing endpoint** at that path — already returns `last_ping`, `geofence_events`, `drive_segments`, `routing_events`, `moves`, `locations`. Add tracking_status + ETA + activity-log payloads. | Task 33 |
+| Create new `components/loads/tabs/TrackingTab.js` | **Extend the existing component** — already wires up the tracking endpoint. Add ETA display + breadcrumb polyline overlay + activity log. | Task 37 |
+| Geofence Phase 2 reuses ping infra | **Phase 2 also reuses `geofence_events` natively** (already shipped as a table from 036). Smaller Phase 2 lift. | Future (out of scope here) |
+
+**Column-name conventions** to use throughout the plan (these match migration 036, NOT the original plan's terms):
+- ping table: `driver_location_pings` (not `move_position_snapshots`)
+- ping lat/lng: `latitude` + `longitude` (NUMERIC(10,7); not `lat`/`lng` NUMERIC(9,6)/(10,6))
+- ping heading: `heading` (NUMERIC(5,1); not `heading_deg INTEGER`)
+- ping source: `source` (CHECK `'eld' | 'mobile_app' | 'manual'`); driver-app pings always use `'mobile_app'`
+- driver-level current location: `drivers.last_latitude` + `drivers.last_longitude` + `drivers.last_location_at` + `drivers.last_location_source` + `drivers.last_speed_mph` + `drivers.last_heading`
+
+When implementing tasks 6, 17, 23, 30, 31, 32, 33, 35, 37, 42 — read this section first. Each affected task has an inline reminder of which deltas apply.
+
 ### Task 1: Migration 102 — schema
 
 **Files:**
 - Create: `supabase/migrations/102_driver_move_tracking.sql`
 
-- [ ] **Step 1: Write migration**
+- [ ] **Step 1: Write migration** (RECONCILED — see Schema reconciliation note above)
 
 ```sql
 -- ============================================================
 -- Migration 102: Driver Move-Tracking Foundation
 -- ============================================================
--- Adds GPS ping time-series, tracking session state on moves,
--- ETA cache on routing events, driver auth + consent columns,
--- move-tracking history table, login attempts table, feature flag.
+-- Builds on existing migration 036 driver-tracking scaffolding
+-- (driver_location_pings, geofence_events, drive_segments, plus
+-- drivers.last_latitude/longitude/last_location_at/etc.). Reuses
+-- where the shape matches; adds only what's net-new for FU-085.
+--
+-- Net-new additions:
+--   - driver_location_pings.move_id + .battery_pct (extend existing table)
+--   - order_container_moves: tracking_status state machine + session +
+--     last_ping_at + ping_count + eta_recompute_count
+--   - order_routing_events: ETA cache columns
+--   - drivers: 8 auth + consent columns
+--   - move_tracking_session_history audit table
+--   - driver_auth_attempts rate-limit table
+--   - move_tracking feature flag
+--
+-- Re-used (no new schema): driver_location_pings (table from 036),
+-- drivers.last_latitude/last_longitude/last_location_at/last_speed_mph/
+-- last_heading/last_location_source (columns from 036), geofence_events
+-- (table from 036, used by Phase 2).
 --
 -- Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md
 -- FU-085. PR 1 of 7.
@@ -140,39 +189,36 @@ PRs 2–7 all depend on PR 1. Deliverables: migration 102 (schema only — appli
 
 BEGIN;
 
--- 1. Time-series GPS pings
-CREATE TABLE IF NOT EXISTS move_position_snapshots (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
-  move_id UUID NOT NULL REFERENCES order_container_moves(id) ON DELETE CASCADE,
-  driver_id UUID NOT NULL REFERENCES drivers(id) ON DELETE RESTRICT,
+-- 1. Extend driver_location_pings (from migration 036) with move scoping +
+--    battery telemetry. The existing table has the right shape:
+--      - driver_id (NOT NULL) + order_id (nullable)
+--      - latitude/longitude NUMERIC(10,7) with valid_latitude/longitude CHECKs
+--      - source CHECK ('eld','mobile_app','manual')
+--      - heading NUMERIC(5,1), speed_mph NUMERIC(5,1), accuracy_meters NUMERIC(7,1)
+--      - eld_provider, eld_device_id (nullable; populated only for eld source)
+--      - recorded_at + received_at
+--      - RLS policies (pings_select, pings_insert)
+--    We add per-move scoping for breadcrumb fetch + battery for the mobile
+--    app's ping payload.
+ALTER TABLE driver_location_pings
+  ADD COLUMN IF NOT EXISTS move_id UUID REFERENCES order_container_moves(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS battery_pct INTEGER;
 
-  lat NUMERIC(9,6) NOT NULL,
-  lng NUMERIC(10,6) NOT NULL,
-  accuracy_meters NUMERIC(7,1),
-  speed_mph NUMERIC(5,1),
-  heading_deg INTEGER,
-  battery_pct INTEGER,
+CREATE INDEX IF NOT EXISTS idx_driver_location_pings_move_recorded
+  ON driver_location_pings(move_id, recorded_at DESC) WHERE move_id IS NOT NULL;
 
-  recorded_at TIMESTAMPTZ NOT NULL,
-  received_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_position_snapshots_move_recorded
-  ON move_position_snapshots(move_id, recorded_at DESC);
-CREATE INDEX IF NOT EXISTS idx_position_snapshots_driver_recorded
-  ON move_position_snapshots(driver_id, recorded_at DESC);
-CREATE INDEX IF NOT EXISTS idx_position_snapshots_tenant_recorded
-  ON move_position_snapshots(tenant_id, recorded_at DESC);
-
--- 2. Tracking session state on order_container_moves
+-- 2. Tracking session state on order_container_moves.
+--    NOT adding current_lat/current_lng — drivers.last_latitude/last_longitude
+--    (from migration 036) already serves "where is the driver now". A driver
+--    works one in_transit/on_site move at a time, so per-driver denorm is
+--    sufficient. last_ping_at IS added here for staleness detection without
+--    a join (the stale-ping cron filters in_transit moves where last_ping_at
+--    < now() - 10min).
 ALTER TABLE order_container_moves
   ADD COLUMN IF NOT EXISTS tracking_status TEXT NOT NULL DEFAULT 'idle'
     CHECK (tracking_status IN ('idle','in_transit','on_site','paused','completed')),
   ADD COLUMN IF NOT EXISTS session_started_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS session_ended_at TIMESTAMPTZ,
-  ADD COLUMN IF NOT EXISTS current_lat NUMERIC(9,6),
-  ADD COLUMN IF NOT EXISTS current_lng NUMERIC(10,6),
   ADD COLUMN IF NOT EXISTS last_ping_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS ping_count INTEGER NOT NULL DEFAULT 0,
   ADD COLUMN IF NOT EXISTS eta_recompute_count INTEGER NOT NULL DEFAULT 0;
@@ -183,7 +229,7 @@ ALTER TABLE order_routing_events
   ADD COLUMN IF NOT EXISTS eta_updated_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS eta_distance_remaining_miles NUMERIC(7,2);
 
--- 4. Driver auth + consent on drivers
+-- 4. Driver auth + consent on drivers (no overlap with 036's location columns)
 ALTER TABLE drivers
   ADD COLUMN IF NOT EXISTS password_hash TEXT,
   ADD COLUMN IF NOT EXISTS password_set_at TIMESTAMPTZ,
@@ -224,8 +270,11 @@ CREATE TABLE IF NOT EXISTS driver_auth_attempts (
 CREATE INDEX IF NOT EXISTS idx_driver_auth_attempts_username_recent
   ON driver_auth_attempts(username, attempted_at DESC);
 
--- 7. Feature flag row
-INSERT INTO feature_flags (name, description, default_enabled)
+-- 7. Feature flag row.
+--    NOTE: feature_flags table uses is_active (NOT default_enabled).
+--    is_active=false registers globally-disabled; per-tenant
+--    tenant_feature_flags rows opt individual tenants in.
+INSERT INTO feature_flags (name, description, is_active)
 VALUES ('move_tracking', 'Driver mobile move tracking with live ETA + breadcrumbs', false)
 ON CONFLICT (name) DO NOTHING;
 

--- a/docs/superpowers/plans/2026-04-24-driver-move-tracking.md
+++ b/docs/superpowers/plans/2026-04-24-driver-move-tracking.md
@@ -292,7 +292,9 @@ git commit -m "feat(driver-tracking): migration 102 — GPS pings + tracking ses
 
 - [ ] **Step 3: Apply to live Supabase**
 
-User opens Supabase SQL Editor, pastes contents of `102_driver_move_tracking.sql`, runs. Verify in dashboard:
+⚠️ **PREREQUISITE:** Migration 036 (`supabase/migrations/036_driver_tracking.sql`) must be applied first. It was committed long ago as ELD-integration scaffolding but never landed on the live database, so `driver_location_pings` (which 102 extends) doesn't exist in production. 036 is idempotent (every CREATE/ADD uses `IF NOT EXISTS`) so applying it now is safe even if some columns happen to already exist. Apply 036 first, then 102.
+
+User opens Supabase SQL Editor, pastes contents of `036_driver_tracking.sql`, runs (`Success. No rows returned.`), then pastes contents of `102_driver_move_tracking.sql`, runs. Verify in dashboard after both:
 - `move_position_snapshots` table exists with 3 indexes
 - `order_container_moves` has 8 new columns (tracking_status default 'idle')
 - `order_routing_events` has 3 new ETA columns

--- a/hooks/useDriverPlanner.js
+++ b/hooks/useDriverPlanner.js
@@ -59,6 +59,40 @@ function reducer(state, action) {
       renumberSortOrder(next.movesByDriverId[driverId]);
       return next;
     }
+    case 'UPDATE_TRACKING': {
+      const { moveId, tracking } = action.payload;
+      // Try assigned buckets first
+      const driverId = Object.keys(state.movesByDriverId).find((did) =>
+        state.movesByDriverId[did].some((m) => m.id === moveId),
+      );
+      if (driverId) {
+        return {
+          ...state,
+          movesByDriverId: {
+            ...state.movesByDriverId,
+            [driverId]: state.movesByDriverId[driverId].map((m) =>
+              m.id === moveId ? { ...m, ...tracking } : m,
+            ),
+          },
+        };
+      }
+      // Also check unassigned buckets
+      const bucketKey = Object.keys(state.unassignedBuckets).find((k) =>
+        state.unassignedBuckets[k].some((m) => m.id === moveId),
+      );
+      if (bucketKey) {
+        return {
+          ...state,
+          unassignedBuckets: {
+            ...state.unassignedBuckets,
+            [bucketKey]: state.unassignedBuckets[bucketKey].map((m) =>
+              m.id === moveId ? { ...m, ...tracking } : m,
+            ),
+          },
+        };
+      }
+      return state;
+    }
     case 'ROLLBACK':
       return action.snapshot;
     default:
@@ -95,6 +129,28 @@ function removeMoveEverywhere(state, moveId) {
 
 function renumberSortOrder(arr) {
   arr.forEach((m, i) => (m.sort_order = i));
+}
+
+// ── Tracking-only pre-filter ─────────────────────────────────────────────────
+// Columns written exclusively by the GPS-ping path. A Realtime UPDATE that only
+// touches these columns does NOT affect planner layout — dispatch a targeted
+// UPDATE_TRACKING action instead of a full refetch.
+const TRACKING_ONLY_KEYS = new Set([
+  'tracking_status',
+  'last_ping_at',
+  'ping_count',
+  'session_started_at',
+  'session_ended_at',
+  'eta_recompute_count',
+]);
+
+function isTrackingOnlyChange(oldRow, newRow) {
+  if (!oldRow || !newRow) return false;
+  for (const key of Object.keys(newRow)) {
+    if (newRow[key] === oldRow[key]) continue;
+    if (!TRACKING_ONLY_KEYS.has(key)) return false;
+  }
+  return true;
 }
 
 export default function useDriverPlanner({ date, driverSearch = '', branchId = null, includeInactive = false }) {
@@ -149,6 +205,18 @@ export default function useDriverPlanner({ date, driverSearch = '', branchId = n
           const old = payload.old || {};
           const relevantDate = (m) => m.scheduled_date === date || m.driver_id == null;
           if (!relevantDate(nw) && !relevantDate(old)) return;
+
+          // Tracking-only UPDATE: merge columns directly without a full refetch.
+          // This keeps GPS-ping updates (60 s cadence) from hammering the API.
+          if (payload.eventType === 'UPDATE' && isTrackingOnlyChange(payload.old, payload.new)) {
+            const tracking = {};
+            for (const k of TRACKING_ONLY_KEYS) {
+              if (k in payload.new) tracking[k] = payload.new[k];
+            }
+            dispatch({ type: 'UPDATE_TRACKING', payload: { moveId: payload.new.id, tracking } });
+            return;
+          }
+
           scheduleRefetch();
         }
       )

--- a/lib/cron/breadcrumb-retention.js
+++ b/lib/cron/breadcrumb-retention.js
@@ -1,0 +1,6 @@
+// lib/cron/breadcrumb-retention.js
+export const RETENTION_DAYS = 90;
+
+export function cutoffIso(daysBack = RETENTION_DAYS, nowMs = Date.now()) {
+  return new Date(nowMs - daysBack * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/lib/cron/stale-ping-pause.js
+++ b/lib/cron/stale-ping-pause.js
@@ -1,0 +1,16 @@
+// lib/cron/stale-ping-pause.js
+/**
+ * Pure helper: filter moves that are in_transit and haven't pinged in 10+ min.
+ * Caller flips them to 'paused' via transitionTrackingSession with actor_type='system'.
+ */
+
+export const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
+export function findStaleMoves(moves, nowMs = Date.now()) {
+  return (moves || []).filter((m) => {
+    if (m.tracking_status !== 'in_transit') return false;
+    if (!m.last_ping_at) return false;
+    const ageMs = nowMs - new Date(m.last_ping_at).getTime();
+    return ageMs >= STALE_THRESHOLD_MS;
+  });
+}

--- a/lib/dispatcher/tracking-display.js
+++ b/lib/dispatcher/tracking-display.js
@@ -1,0 +1,51 @@
+/**
+ * Display formatters for tracking data on dispatcher surfaces.
+ * Shared between MoveCell and TrackingTab.
+ */
+
+export function fmtRelativeETA(etaIso) {
+  if (!etaIso) return '—';
+  const ms = new Date(etaIso).getTime() - Date.now();
+  if (ms <= 0) return 'now';
+  const totalMin = Math.round(ms / 60000);
+  if (totalMin < 60) return `${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${h}h ${m}m`;
+}
+
+export function fmtAbsoluteETA(etaIso) {
+  if (!etaIso) return '—';
+  const d = new Date(etaIso);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+export function fmtOnSiteDuration(arrivedAtIso) {
+  if (!arrivedAtIso) return '—';
+  const ms = Date.now() - new Date(arrivedAtIso).getTime();
+  if (ms < 0) return '—';
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function freshnessColor(lastPingAtIso) {
+  if (!lastPingAtIso) return 'red';
+  const ms = Date.now() - new Date(lastPingAtIso).getTime();
+  if (ms < 2 * 60 * 1000) return 'green';
+  if (ms < 10 * 60 * 1000) return 'amber';
+  return 'red';
+}
+
+export function freshnessColorClass(color) {
+  return {
+    green: 'bg-green-500',
+    amber: 'bg-amber-500',
+    red: 'bg-red-500',
+  }[color] || 'bg-gray-400';
+}

--- a/lib/driver-app/auth.js
+++ b/lib/driver-app/auth.js
@@ -1,0 +1,51 @@
+// lib/driver-app/auth.js
+/**
+ * Client-side JWT storage + fetch wrapper for the driver web stub.
+ * Token in localStorage. On 401, redirect to /driver/login.
+ */
+
+const TOKEN_KEY = 'dd_driver_token';
+const ID_KEY = 'dd_driver_id';
+const NAME_KEY = 'dd_driver_name';
+
+export function getToken() {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(TOKEN_KEY);
+}
+
+export function setSession({ token, driverId, name }) {
+  window.localStorage.setItem(TOKEN_KEY, token);
+  if (driverId) window.localStorage.setItem(ID_KEY, driverId);
+  if (name != null) window.localStorage.setItem(NAME_KEY, name);
+}
+
+export function clearSession() {
+  window.localStorage.removeItem(TOKEN_KEY);
+  window.localStorage.removeItem(ID_KEY);
+  window.localStorage.removeItem(NAME_KEY);
+}
+
+export function getDriverId() {
+  return typeof window === 'undefined' ? null : window.localStorage.getItem(ID_KEY);
+}
+
+/**
+ * Authenticated fetch. Auto-attaches Authorization header. On 401 redirects
+ * to /driver/login. On all other responses, returns the Response unchanged.
+ */
+export async function driverFetch(url, options = {}) {
+  const token = getToken();
+  const headers = { ...(options.headers || {}) };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (options.body && !(options.body instanceof FormData) && !headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const res = await fetch(url, { ...options, headers });
+  if (res.status === 401) {
+    clearSession();
+    if (typeof window !== 'undefined' && window.location.pathname.startsWith('/driver')) {
+      window.location.href = '/driver/login';
+    }
+  }
+  return res;
+}

--- a/lib/driver-app/geolocation-watcher.js
+++ b/lib/driver-app/geolocation-watcher.js
@@ -1,0 +1,92 @@
+// lib/driver-app/geolocation-watcher.js
+/**
+ * navigator.geolocation wrapper with adaptive cadence:
+ *   - moving (last 2 pings >= 100m apart):  60s
+ *   - stationary (< 100m apart):           180s
+ *   - on-site (caller passes flag):        300s
+ *
+ * Returns a normalized ping shape: { latitude, longitude, accuracy_meters,
+ * speed_mph, heading, battery_pct, recorded_at }.
+ */
+
+const MOVING_INTERVAL_MS = 60 * 1000;
+const STATIONARY_INTERVAL_MS = 180 * 1000;
+const ON_SITE_INTERVAL_MS = 300 * 1000;
+const MOVEMENT_THRESHOLD_M = 100;
+const METERS_PER_MILE = 1609.344;
+
+function haversineMeters(a, b) {
+  const R = 6371000;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const A = Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.latitude)) * Math.cos(toRad(b.latitude)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(A));
+}
+
+export function pickInterval({ lastPing, currentPing, onSite }) {
+  if (onSite) return ON_SITE_INTERVAL_MS;
+  if (!lastPing) return MOVING_INTERVAL_MS;
+  const distance = haversineMeters(lastPing, currentPing);
+  return distance >= MOVEMENT_THRESHOLD_M ? MOVING_INTERVAL_MS : STATIONARY_INTERVAL_MS;
+}
+
+/**
+ * Start a geolocation watcher that emits normalized pings via onPing(ping).
+ * Calls navigator.geolocation.getCurrentPosition() each cycle (not watchPosition,
+ * which doesn't honor cadence — getCurrentPosition + setTimeout gives precise
+ * control).
+ *
+ * Returns a { stop() } handle.
+ */
+export function startWatcher({ onPing, onError, getOnSite, getBatteryPct }) {
+  let stopped = false;
+  let lastPing = null;
+  let timeoutId = null;
+
+  async function tick() {
+    if (stopped) return;
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      onError?.(new Error('geolocation unavailable'));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        if (stopped) return;
+        const { coords, timestamp } = position;
+        const ping = {
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          accuracy_meters: coords.accuracy ?? null,
+          speed_mph: coords.speed != null ? (coords.speed * 3600) / METERS_PER_MILE : null,
+          heading: coords.heading ?? null,
+          battery_pct: getBatteryPct?.() ?? null,
+          recorded_at: new Date(timestamp).toISOString(),
+        };
+        onPing(ping);
+        const onSite = !!getOnSite?.();
+        const interval = pickInterval({ lastPing, currentPing: ping, onSite });
+        lastPing = ping;
+        timeoutId = setTimeout(tick, interval);
+      },
+      (err) => {
+        if (stopped) return;
+        onError?.(err);
+        // Retry in MOVING_INTERVAL on error (better than backing off forever)
+        timeoutId = setTimeout(tick, MOVING_INTERVAL_MS);
+      },
+      { enableHighAccuracy: true, timeout: 30000, maximumAge: 0 },
+    );
+  }
+
+  // First tick: fire immediately so the caller gets a ping right away.
+  tick();
+
+  return {
+    stop() {
+      stopped = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    },
+  };
+}

--- a/lib/driver-app/offline-queue.js
+++ b/lib/driver-app/offline-queue.js
@@ -1,0 +1,99 @@
+// lib/driver-app/offline-queue.js
+/**
+ * IndexedDB-backed FIFO queue for offline pings + queued actions.
+ * Cap 100 entries; oldest dropped on overflow. Drains via the batch endpoint
+ * on `online` event.
+ */
+
+const DB_NAME = 'dd_driver_app';
+const DB_VERSION = 1;
+const STORE = 'pendingPings';
+const MAX_QUEUE = 100;
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+export async function enqueue(item) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    const req = store.add({ ...item, createdAt: Date.now() });
+    req.onsuccess = async () => {
+      // Cap enforcement: count, drop oldest if over.
+      const count = await new Promise((r) => {
+        const c = store.count();
+        c.onsuccess = () => r(c.result);
+      });
+      if (count > MAX_QUEUE) {
+        const cursor = store.openCursor();
+        cursor.onsuccess = (e) => {
+          const cur = e.target.result;
+          if (cur) cur.delete();
+        };
+      }
+      resolve(req.result);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function drainAll() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    const items = [];
+    const req = store.openCursor();
+    req.onsuccess = (e) => {
+      const cur = e.target.result;
+      if (cur) {
+        items.push(cur.value);
+        cur.continue();
+      }
+    };
+    tx.oncomplete = () => resolve(items);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function clearAll() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function flushToServer({ driverFetch }) {
+  const items = await drainAll();
+  if (items.length === 0) return { flushed: 0 };
+  // Only ping items in v1 — actions are not queued (driver gets immediate
+  // feedback in the UI and can re-tap if offline).
+  const pingItems = items
+    .filter((i) => i.type === 'ping')
+    .map((i) => ({ moveId: i.payload.moveId, gpsPing: i.payload.gpsPing }));
+  if (pingItems.length === 0) return { flushed: 0 };
+  const res = await driverFetch('/api/driver/pings/batch', {
+    method: 'POST',
+    body: JSON.stringify({ items: pingItems }),
+  });
+  if (res.ok) {
+    await clearAll();
+    return { flushed: pingItems.length };
+  }
+  return { flushed: 0, error: res.status };
+}

--- a/lib/driver-app/ping-scheduler.js
+++ b/lib/driver-app/ping-scheduler.js
@@ -1,0 +1,61 @@
+// lib/driver-app/ping-scheduler.js
+/**
+ * Orchestrator: subscribes to geolocation watcher, decides live vs buffer,
+ * stops on completed.
+ */
+
+import { startWatcher } from './geolocation-watcher.js';
+import { enqueue, flushToServer } from './offline-queue.js';
+import { driverFetch } from './auth.js';
+
+export function startScheduler({ moveId, getMoveStatus, onSendError }) {
+  let online = typeof navigator !== 'undefined' ? navigator.onLine : true;
+
+  function setOnline(v) {
+    online = v;
+    if (v) flushToServer({ driverFetch }).catch(() => {});
+  }
+
+  function handleOnline() { setOnline(true); }
+  function handleOffline() { setOnline(false); }
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+  }
+
+  const watcher = startWatcher({
+    onPing: async (ping) => {
+      const status = getMoveStatus?.();
+      if (status === 'completed' || status === 'idle') return;  // shouldn't happen but defensive
+      if (online) {
+        try {
+          const res = await driverFetch(`/api/driver/moves/${moveId}/ping`, {
+            method: 'POST',
+            body: JSON.stringify({ gpsPing: ping }),
+          });
+          if (!res.ok) {
+            await enqueue({ type: 'ping', payload: { moveId, gpsPing: ping } });
+            onSendError?.(res.status);
+          }
+        } catch (err) {
+          await enqueue({ type: 'ping', payload: { moveId, gpsPing: ping } });
+          onSendError?.(err);
+        }
+      } else {
+        await enqueue({ type: 'ping', payload: { moveId, gpsPing: ping } });
+      }
+    },
+    onError: (err) => onSendError?.(err),
+    getOnSite: () => getMoveStatus?.() === 'on_site',
+  });
+
+  return {
+    stop() {
+      watcher.stop();
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('online', handleOnline);
+        window.removeEventListener('offline', handleOffline);
+      }
+    },
+  };
+}

--- a/lib/driver-app/undo-timer.js
+++ b/lib/driver-app/undo-timer.js
@@ -1,0 +1,32 @@
+// lib/driver-app/undo-timer.js
+/**
+ * 2-min undo countdown helper. Tracks last-action timestamp in sessionStorage.
+ */
+
+const KEY = 'dd_driver_last_action_at';
+const WINDOW_MS = 2 * 60 * 1000;
+
+export function recordAction() {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.setItem(KEY, String(Date.now()));
+}
+
+export function clearAction() {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(KEY);
+}
+
+export function getRemainingMs() {
+  if (typeof window === 'undefined') return 0;
+  const at = parseInt(window.sessionStorage.getItem(KEY) || '0', 10);
+  if (!at) return 0;
+  const remaining = WINDOW_MS - (Date.now() - at);
+  return remaining > 0 ? remaining : 0;
+}
+
+export function fmtRemaining(ms) {
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}

--- a/lib/driver-auth/middleware.js
+++ b/lib/driver-auth/middleware.js
@@ -1,0 +1,73 @@
+/**
+ * requireDriver — JWT-based middleware for /api/driver/* endpoints.
+ * Validates token, looks up driver, checks status + session_min_iat.
+ * On success: returns { driverId, tenantId, driver }.
+ * On failure: writes 401 to res and returns null.
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md §4
+ */
+
+import { verifyDriverJWT } from './utils.js';
+
+let _serviceClient = null;
+export function __setServiceClientForTesting(svc) {
+  _serviceClient = svc;
+}
+
+async function svcClient() {
+  if (_serviceClient) return _serviceClient;
+  // Lazy import so tests can inject a mock without loading the Supabase stack.
+  const { getServiceClient } = await import('../tenant-api.js');
+  return getServiceClient();
+}
+
+export async function requireDriver(req, res) {
+  const auth = req.headers?.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'auth_required' });
+    return null;
+  }
+  const token = auth.slice('Bearer '.length).trim();
+
+  let claims;
+  try {
+    claims = verifyDriverJWT(token);
+  } catch (e) {
+    res.status(401).json({ error: 'auth_invalid', detail: e.message });
+    return null;
+  }
+
+  const svc = await svcClient();
+  const { data: driver, error } = await svc
+    .from('drivers')
+    .select('id, tenant_id, name, username, status, session_min_iat, location_tracking_enabled, password_must_change, tracking_consented_at, tracking_consent_version, tracking_revoked_at')
+    .eq('id', claims.driverId)
+    .eq('tenant_id', claims.tenantId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (error || !driver) {
+    res.status(401).json({ error: 'driver_not_found' });
+    return null;
+  }
+
+  if (driver.status !== 'active') {
+    res.status(401).json({ error: 'driver_inactive' });
+    return null;
+  }
+
+  // session_min_iat: any token issued before this is invalid (revocation pivot).
+  // claims.iat is in seconds; session_min_iat is ISO string.
+  const minIatMs = new Date(driver.session_min_iat).getTime();
+  const tokenIatMs = (claims.iat ?? 0) * 1000;
+  if (tokenIatMs < minIatMs) {
+    res.status(401).json({ error: 'auth_revoked' });
+    return null;
+  }
+
+  return {
+    driverId: driver.id,
+    tenantId: driver.tenant_id,
+    driver,
+  };
+}

--- a/lib/driver-auth/tracking-gates.js
+++ b/lib/driver-auth/tracking-gates.js
@@ -1,0 +1,31 @@
+// lib/driver-auth/tracking-gates.js
+/**
+ * Three-gate check applied before any driver tracking action or ping:
+ *   1. Tenant feature flag (move_tracking) on?
+ *   2. Per-driver location_tracking_enabled?
+ *   3. Driver consent currently valid?
+ *
+ * Returns null on pass; { status, error } object on fail.
+ * Caller writes the failure response.
+ */
+
+import { isConsentValid } from '../driver-consent/version.js';
+
+export async function checkTrackingGates({ supabase, tenantId, driver }) {
+  // 1. Tenant feature flag
+  const { data: tff } = await supabase
+    .from('tenant_feature_flags')
+    .select('enabled, feature_flag:feature_flags!inner(name)')
+    .eq('tenant_id', tenantId)
+    .eq('feature_flag.name', 'move_tracking')
+    .maybeSingle();
+  if (!tff?.enabled) return { status: 403, error: 'feature_disabled' };
+
+  // 2. Per-driver toggle
+  if (!driver.location_tracking_enabled) return { status: 403, error: 'tracking_disabled' };
+
+  // 3. Consent
+  if (!isConsentValid(driver)) return { status: 403, error: 'consent_required' };
+
+  return null;
+}

--- a/lib/driver-auth/utils.js
+++ b/lib/driver-auth/utils.js
@@ -1,0 +1,66 @@
+/**
+ * Driver-auth utilities: JWT signing/verification, bcrypt password hashing,
+ * temp-password generation. Driver tokens are 30-day TTL with `iat` claim
+ * for revocation pivot (drivers.session_min_iat).
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md §4
+ */
+
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { randomBytes } from 'node:crypto';
+
+export const TOKEN_TTL_DAYS = 30;
+const BCRYPT_ROUNDS = 10;
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';  // no 0/O/1/I/l
+
+export async function hashPassword(plaintext) {
+  return bcrypt.hash(plaintext, BCRYPT_ROUNDS);
+}
+
+export async function verifyPassword(plaintext, hash) {
+  if (!hash) return false;
+  return bcrypt.compare(plaintext, hash);
+}
+
+/**
+ * Sign a driver JWT.
+ * @param {object} payload  { driverId, tenantId }
+ * @param {string} secret   defaults to process.env.DRIVER_JWT_SECRET
+ * @returns {string} JWT
+ */
+export function signDriverJWT(payload, secret) {
+  const finalSecret = secret ?? process.env.DRIVER_JWT_SECRET;
+  if (!finalSecret) throw new Error('DRIVER_JWT_SECRET is not set');
+  return jwt.sign(
+    { driverId: payload.driverId, tenantId: payload.tenantId },
+    finalSecret,
+    {
+      expiresIn: `${TOKEN_TTL_DAYS}d`,
+      issuer: 'drayagedirect-driver',
+    },
+  );
+}
+
+/**
+ * Verify a driver JWT. Throws on invalid/expired/tampered.
+ * @returns {object} decoded claims (includes iat, exp, driverId, tenantId)
+ */
+export function verifyDriverJWT(token, secret) {
+  const finalSecret = secret ?? process.env.DRIVER_JWT_SECRET;
+  if (!finalSecret) throw new Error('DRIVER_JWT_SECRET is not set');
+  return jwt.verify(token, finalSecret, { issuer: 'drayagedirect-driver' });
+}
+
+/**
+ * Generate a random 8-char alphanumeric password (no ambiguous chars).
+ * For dispatcher-handed-off temporary passwords.
+ */
+export function generateTempPassword() {
+  const bytes = randomBytes(8);
+  let out = '';
+  for (let i = 0; i < 8; i++) {
+    out += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return out;
+}

--- a/lib/driver-consent/text.js
+++ b/lib/driver-consent/text.js
@@ -1,0 +1,24 @@
+// lib/driver-consent/text.js
+// LEGAL REVIEW REQUIRED BEFORE PROD — final wording must be reviewed by counsel.
+
+export const CONSENT_TITLE = 'DrayageDirect — Location Tracking Notice';
+
+export const CONSENT_BODY = `Your trucking company uses DrayageDirect to operate.
+This app reports your location to your dispatcher when:
+  • You start a move
+  • You travel between stops
+  • You arrive at and leave each stop
+
+Your location is recorded only while you are working a move.
+Recording stops automatically when each move completes.
+
+Your dispatcher can see your current location and your route
+history for up to 90 days. They cannot see your location
+between shifts.
+
+You can revoke this permission anytime in Settings. If you
+revoke, you will need to report your arrivals and departures
+to your dispatcher manually.
+
+By tapping Accept, you agree to share your location while
+working moves on this device.`;

--- a/lib/driver-consent/version.js
+++ b/lib/driver-consent/version.js
@@ -1,0 +1,22 @@
+// lib/driver-consent/version.js
+/**
+ * Bumped manually whenever the consent text in text.js changes materially.
+ * On bump, all drivers re-prompt at next app open.
+ */
+export const CURRENT_CONSENT_VERSION = 1;
+
+/**
+ * @param {{ tracking_consented_at: string|null, tracking_revoked_at: string|null, tracking_consent_version: number|null }} driver
+ * @returns {boolean}
+ */
+export function isConsentValid(driver) {
+  if (!driver?.tracking_consented_at) return false;
+  if (driver.tracking_consent_version !== CURRENT_CONSENT_VERSION) return false;
+  if (
+    driver.tracking_revoked_at &&
+    new Date(driver.tracking_revoked_at) >= new Date(driver.tracking_consented_at)
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/lib/google-maps/server-distance.js
+++ b/lib/google-maps/server-distance.js
@@ -1,0 +1,113 @@
+/**
+ * Server-side Google Distance Matrix wrapper.
+ * - Reads GOOGLE_MAPS_SERVER_API_KEY (separate restricted server key)
+ * - In-memory LRU cache keyed by (origLat3, origLng3, destLat3, destLng3, eventId), 60s TTL
+ * - Cost-gate: rejects when recomputeCount >= 50
+ * - Returns { eta_arrival_at, distance_remaining_miles, cached: bool }
+ *           or { skipped: true, reason: 'cost_cap_reached' }
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md §4
+ */
+
+const CACHE_TTL_MS = 60 * 1000;
+const COST_CAP_PER_MOVE = 50;
+const METERS_PER_MILE = 1609.344;
+
+// Module-level Map; entries: { key -> { value, expiresAt } }. Manual LRU.
+const cache = new Map();
+
+export function __resetCacheForTesting() {
+  cache.clear();
+}
+
+function round3(n) {
+  return Math.round(n * 1000) / 1000;
+}
+
+export function buildCacheKey({ origin, destination }) {
+  return `${round3(origin.lat)},${round3(origin.lng)}|${round3(destination.lat)},${round3(destination.lng)}|${destination.eventId}`;
+}
+
+function readFromCache(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function writeToCache(key, value) {
+  // Cap cache size at 1000; on overflow drop oldest insertion.
+  if (cache.size >= 1000) {
+    const firstKey = cache.keys().next().value;
+    cache.delete(firstKey);
+  }
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/**
+ * @param {object} params
+ * @param {{lat: number, lng: number}} params.origin
+ * @param {{lat: number, lng: number, eventId: string}} params.destination
+ * @param {number} params.recomputeCount  current move.eta_recompute_count
+ * @param {string} [params.apiKey]        defaults to process.env.GOOGLE_MAPS_SERVER_API_KEY
+ * @param {Function} [params.fetchImpl]   defaults to global fetch (test override)
+ * @returns {Promise<{eta_arrival_at?: string, distance_remaining_miles?: number, cached?: boolean, skipped?: boolean, reason?: string}>}
+ */
+export async function recomputeETA({
+  origin,
+  destination,
+  recomputeCount,
+  apiKey,
+  fetchImpl,
+}) {
+  if (recomputeCount >= COST_CAP_PER_MOVE) {
+    return { skipped: true, reason: 'cost_cap_reached' };
+  }
+
+  const key = buildCacheKey({ origin, destination });
+  const cached = readFromCache(key);
+  if (cached) {
+    return { ...cached, cached: true };
+  }
+
+  const finalKey = apiKey ?? process.env.GOOGLE_MAPS_SERVER_API_KEY;
+  if (!finalKey) {
+    throw new Error('GOOGLE_MAPS_SERVER_API_KEY is not set');
+  }
+
+  const f = fetchImpl ?? globalThis.fetch;
+  const url = new URL('https://maps.googleapis.com/maps/api/distancematrix/json');
+  url.searchParams.set('origins', `${origin.lat},${origin.lng}`);
+  url.searchParams.set('destinations', `${destination.lat},${destination.lng}`);
+  url.searchParams.set('departure_time', 'now');
+  url.searchParams.set('traffic_model', 'best_guess');
+  url.searchParams.set('units', 'imperial');
+  url.searchParams.set('key', finalKey);
+
+  const res = await f(url.toString());
+  if (!res.ok) {
+    throw new Error(`Distance Matrix HTTP ${res.status}`);
+  }
+  const json = await res.json();
+  const element = json?.rows?.[0]?.elements?.[0];
+  if (!element || element.status !== 'OK') {
+    throw new Error(`Distance Matrix element status: ${element?.status ?? 'no_element'}`);
+  }
+
+  // duration_in_traffic preferred when available; falls back to duration
+  const durationSec = element.duration_in_traffic?.value ?? element.duration?.value;
+  const distanceMeters = element.distance?.value;
+  if (typeof durationSec !== 'number' || typeof distanceMeters !== 'number') {
+    throw new Error('Distance Matrix returned invalid duration/distance');
+  }
+
+  const result = {
+    eta_arrival_at: new Date(Date.now() + durationSec * 1000).toISOString(),
+    distance_remaining_miles: Math.round((distanceMeters / METERS_PER_MILE) * 100) / 100,
+  };
+  writeToCache(key, result);
+  return { ...result, cached: false };
+}

--- a/lib/routing/driver-action.js
+++ b/lib/routing/driver-action.js
@@ -1,0 +1,158 @@
+/**
+ * Composite atomic helper for driver-initiated actions. Wraps:
+ *   1. GPS ping insert into driver_location_pings (source='mobile_app')
+ *   2. ping_count cap enforcement (40 per move)
+ *   3. drivers.last_* denormalization (where-is-driver-now)
+ *   4. order_container_moves.last_ping_at + ping_count update (staleness)
+ *   5. event-status transition (for arrive/depart)
+ *   6. tracking-session transition (for all action types)
+ *
+ * Both transitions reference the inserted ping_id in actor_context.
+ *
+ * Single Postgres transaction is NOT enforced (Supabase JS client doesn't
+ * expose explicit BEGIN/COMMIT). Steps execute serially; partial failures
+ * leave audit history intact via the log-and-continue pattern in helpers.
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md §3
+ * Schema reconciliation note (PR 1 of plan): pings go to driver_location_pings
+ * (NOT move_position_snapshots). Driver-level current location lives on
+ * drivers.last_* (from migration 036), not on order_container_moves.current_*.
+ */
+
+import { transitionEventStatus } from './event-status-transition.js';
+import { transitionTrackingSession } from './tracking-session-transition.js';
+
+const PING_CAP = 40;
+const PING_SOURCE = 'mobile_app';
+
+/**
+ * @param {object} params
+ * @param {object} params.supabase
+ * @param {string} params.tenantId
+ * @param {string} params.moveId
+ * @param {'start'|'arrive'|'depart'|'undo'} params.actionType
+ * @param {string} params.driverId
+ * @param {object} [params.gpsPing]   { latitude, longitude, recorded_at, accuracy_meters?, speed_mph?, heading?, battery_pct? }
+ * @param {string} [params.targetEventId]   required for arrive/depart
+ * @returns {Promise<{ event?: object, move: object, ping_id?: string }>}
+ */
+export async function applyDriverAction({
+  supabase, tenantId, moveId, actionType,
+  driverId, gpsPing, targetEventId,
+}) {
+  // 1. Read current move state
+  const { data: move, error: moveErr } = await supabase
+    .from('order_container_moves')
+    .select('id, tenant_id, driver_id, tracking_status, ping_count, eta_recompute_count')
+    .eq('id', moveId)
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+  if (moveErr) throw moveErr;
+  if (!move) throw new Error(`Move not found: ${moveId}`);
+  if (move.driver_id !== driverId) {
+    throw new Error('forbidden: driver does not own this move');
+  }
+
+  // 2. Cap enforcement
+  if (gpsPing && (move.ping_count ?? 0) >= PING_CAP) {
+    throw new Error('ping_cap_reached');
+  }
+
+  // 3. Insert GPS ping (if provided) into driver_location_pings
+  let pingId = null;
+  if (gpsPing) {
+    const { data: pingRow, error: pingErr } = await supabase
+      .from('driver_location_pings')
+      .insert({
+        tenant_id: tenantId,
+        move_id: moveId,
+        driver_id: driverId,
+        latitude: gpsPing.latitude,
+        longitude: gpsPing.longitude,
+        accuracy_meters: gpsPing.accuracy_meters ?? null,
+        speed_mph: gpsPing.speed_mph ?? null,
+        heading: gpsPing.heading ?? null,
+        battery_pct: gpsPing.battery_pct ?? null,
+        source: PING_SOURCE,
+        recorded_at: gpsPing.recorded_at,
+      })
+      .select()
+      .single();
+    if (pingErr) throw pingErr;
+    pingId = pingRow.id;
+
+    // 3a. Denormalize "where is driver now" onto drivers row.
+    //     drivers.last_* is the single source of truth for current driver
+    //     position (migration 036). NOT duplicated onto order_container_moves.
+    await supabase
+      .from('drivers')
+      .update({
+        last_latitude: gpsPing.latitude,
+        last_longitude: gpsPing.longitude,
+        last_location_at: gpsPing.recorded_at,
+        last_location_source: PING_SOURCE,
+        last_speed_mph: gpsPing.speed_mph ?? null,
+        last_heading: gpsPing.heading ?? null,
+      })
+      .eq('id', driverId)
+      .eq('tenant_id', tenantId);
+
+    // 3b. Bump move's ping_count + last_ping_at (staleness-check column).
+    //     NOTE: deliberately NOT writing current_lat/current_lng — those
+    //     columns don't exist on order_container_moves. drivers.last_latitude/
+    //     longitude is the authoritative source.
+    await supabase
+      .from('order_container_moves')
+      .update({
+        ping_count: (move.ping_count ?? 0) + 1,
+        last_ping_at: gpsPing.recorded_at,
+      })
+      .eq('id', moveId)
+      .eq('tenant_id', tenantId);
+  }
+
+  const actorContext = { source: 'driver_app', ping_id: pingId };
+
+  // 4. Resolve transition targets and fire event-status transition if needed
+  let event = null;
+  let trackingTarget = null;
+
+  if (actionType === 'start') {
+    trackingTarget = 'in_transit';
+  } else if (actionType === 'arrive') {
+    if (!targetEventId) throw new Error('targetEventId required for arrive');
+    event = await transitionEventStatus({
+      supabase, tenantId, eventId: targetEventId, toStatus: 'arrived',
+      actor: { id: driverId, type: 'human', context: actorContext },
+    });
+    trackingTarget = 'on_site';
+  } else if (actionType === 'depart') {
+    if (!targetEventId) throw new Error('targetEventId required for depart');
+    event = await transitionEventStatus({
+      supabase, tenantId, eventId: targetEventId, toStatus: 'departed',
+      actor: { id: driverId, type: 'human', context: actorContext },
+    });
+    // Track-target depends on whether remaining non-terminal events exist.
+    const { data: laterEvents } = await supabase
+      .from('order_routing_events')
+      .select('id, event_status')
+      .eq('tenant_id', tenantId)
+      .eq('move_id', moveId)
+      .neq('event_status', 'departed')
+      .neq('event_status', 'skipped')
+      .neq('id', targetEventId);
+    trackingTarget = (laterEvents && laterEvents.length > 0) ? 'in_transit' : 'completed';
+  } else if (actionType === 'undo') {
+    throw new Error('undo handled by separate path');
+  } else {
+    throw new Error(`unknown actionType: ${actionType}`);
+  }
+
+  // 5. Tracking-session transition
+  const updatedMove = await transitionTrackingSession({
+    supabase, tenantId, moveId, toStatus: trackingTarget,
+    actor: { id: driverId, type: 'human', context: actorContext },
+  });
+
+  return { event, move: updatedMove, ping_id: pingId };
+}

--- a/lib/routing/driver-action.js
+++ b/lib/routing/driver-action.js
@@ -1,7 +1,7 @@
 /**
  * Composite atomic helper for driver-initiated actions. Wraps:
  *   1. GPS ping insert into driver_location_pings (source='mobile_app')
- *   2. ping_count cap enforcement (40 per move)
+ *   2. ping_count cap enforcement (PING_CAP per move)
  *   3. drivers.last_* denormalization (where-is-driver-now)
  *   4. order_container_moves.last_ping_at + ping_count update (staleness)
  *   5. event-status transition (for arrive/depart)
@@ -22,7 +22,15 @@
 import { transitionEventStatus } from './event-status-transition.js';
 import { transitionTrackingSession } from './tracking-session-transition.js';
 
-const PING_CAP = 40;
+// Lifetime cap on GPS pings per move. The original spec specified 40 but
+// real-world drayage moves at the plan's slowest cadence (300s on-site) over
+// an 8-hour shift can legitimately exceed 96; at 60s in-transit cadence over
+// a 4-hour long-haul leg, ~240 pings. 500 covers full-shift in-transit at
+// 60s + a generous offline-queue flush margin while still preventing pure
+// runaway loops. A future fix (FU follow-up) should replace this lifetime
+// cap with a per-time-window rate limiter (pings/min) — that's the real
+// runaway-loop protection. For v1 the lifetime cap is good enough.
+const PING_CAP = 500;
 const PING_SOURCE = 'mobile_app';
 
 /**
@@ -49,6 +57,10 @@ export async function applyDriverAction({
     .maybeSingle();
   if (moveErr) throw moveErr;
   if (!move) throw new Error(`Move not found: ${moveId}`);
+  if (move.driver_id == null) {
+    // Distinct from forbidden — endpoint will surface as 409 conflict, not 403.
+    throw new Error('move_unassigned');
+  }
   if (move.driver_id !== driverId) {
     throw new Error('forbidden: driver does not own this move');
   }
@@ -84,7 +96,11 @@ export async function applyDriverAction({
     // 3a. Denormalize "where is driver now" onto drivers row.
     //     drivers.last_* is the single source of truth for current driver
     //     position (migration 036). NOT duplicated onto order_container_moves.
-    await supabase
+    //     Log-and-continue: a denorm failure here would leave the dispatcher
+    //     UI showing stale position, but the ping itself is durable and the
+    //     primary state transitions still happen. Better than aborting the
+    //     whole composite mid-flight.
+    const { error: denormErr } = await supabase
       .from('drivers')
       .update({
         last_latitude: gpsPing.latitude,
@@ -96,12 +112,15 @@ export async function applyDriverAction({
       })
       .eq('id', driverId)
       .eq('tenant_id', tenantId);
+    if (denormErr) {
+      console.error(`driver denorm update failed for ${driverId}:`, denormErr.message);
+    }
 
     // 3b. Bump move's ping_count + last_ping_at (staleness-check column).
     //     NOTE: deliberately NOT writing current_lat/current_lng — those
     //     columns don't exist on order_container_moves. drivers.last_latitude/
     //     longitude is the authoritative source.
-    await supabase
+    const { error: counterErr } = await supabase
       .from('order_container_moves')
       .update({
         ping_count: (move.ping_count ?? 0) + 1,
@@ -109,6 +128,9 @@ export async function applyDriverAction({
       })
       .eq('id', moveId)
       .eq('tenant_id', tenantId);
+    if (counterErr) {
+      console.error(`move counter update failed for ${moveId}:`, counterErr.message);
+    }
   }
 
   const actorContext = { source: 'driver_app', ping_id: pingId };

--- a/lib/routing/event-status-transition.js
+++ b/lib/routing/event-status-transition.js
@@ -47,8 +47,16 @@ export function getAllowedNextStatuses(currentStatus) {
  *   1. Reads current event
  *   2. Validates transition is allowed
  *   3. Updates event_status + arrived_at/departed_at (as side effects)
- *   4. Writes history row with actor threading
- *   5. Returns updated event
+ *   4. Fires routing-event triggers (FU-080) on timestamp side-effects.
+ *      Fire-and-forget — errors logged, not bubbled. Triggers run BEFORE
+ *      the history write so a history-row failure cannot prevent a trigger
+ *      that's already been promised to the dispatcher's email pipeline.
+ *      Note: when toStatus='departed' on a forgotten-arrival path
+ *      (event.arrived_at was null and gets auto-filled), BOTH the
+ *      arrived_at and departed_at triggers fire — same physical moment,
+ *      two semantic events.
+ *   5. Writes history row with actor threading (log-and-continue)
+ *   6. Returns updated event
  *
  * Throws on invalid transition, missing actor, or invalid actor.type.
  *

--- a/lib/routing/event-status-transition.js
+++ b/lib/routing/event-status-transition.js
@@ -7,6 +7,14 @@
  * enforces this.
  */
 
+import { fireRoutingEventTriggers as defaultFireRoutingEventTriggers } from '../email-dispatch/routing-event-fire.js';
+
+// Test seam: tests can swap the trigger-firing implementation.
+let _fireRoutingEventTriggers = defaultFireRoutingEventTriggers;
+export function __setFireRoutingEventTriggersForTesting(fn) {
+  _fireRoutingEventTriggers = fn;
+}
+
 const ALLOWED_TRANSITIONS = {
   pending:  ['arrived', 'skipped'],
   arrived:  ['departed', 'skipped'],
@@ -104,6 +112,39 @@ export async function transitionEventStatus({
     .select()
     .single();
   if (updateErr) throw updateErr;
+
+  // FU-080: fire routing-event triggers on timestamp side-effects so driver-tap
+  // and dispatcher-edit paths both reliably fire dispatcher email triggers.
+  // Fire-and-forget — errors logged, not bubbled (matches event-row PUT pattern).
+  const eventType = updated.event_type;
+  if (eventType) {
+    if (toStatus === 'arrived' || (toStatus === 'departed' && update.arrived_at && !event.arrived_at)) {
+      try {
+        await _fireRoutingEventTriggers(supabase, {
+          tenantId,
+          loadId: updated.order_id,
+          eventType,
+          timestampField: 'arrived_at',
+          userId: actor.id ?? null,
+        });
+      } catch (e) {
+        console.error('event-status-transition arrived trigger error:', e?.message || e);
+      }
+    }
+    if (toStatus === 'departed') {
+      try {
+        await _fireRoutingEventTriggers(supabase, {
+          tenantId,
+          loadId: updated.order_id,
+          eventType,
+          timestampField: 'departed_at',
+          userId: actor.id ?? null,
+        });
+      } catch (e) {
+        console.error('event-status-transition departed trigger error:', e?.message || e);
+      }
+    }
+  }
 
   // 4. Write history row (log-and-continue; non-fatal).
   //    Mirrors moves/transition.js — audit gap is preferred to rollback

--- a/lib/routing/tracking-session-transition.js
+++ b/lib/routing/tracking-session-transition.js
@@ -1,0 +1,111 @@
+/**
+ * Tracking-session status transitions on order_container_moves.
+ * Mirrors lib/routing/event-status-transition.js — actor.type is mandatory
+ * (B.1d). Log-and-continue history pattern. Fires NO email triggers (move-
+ * tracking is internal data; tracking_status is not a dispatcher event).
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md §3
+ */
+
+const ALLOWED_TRANSITIONS = {
+  idle:       ['in_transit'],
+  in_transit: ['on_site', 'paused', 'completed'],
+  on_site:    ['in_transit', 'paused', 'completed'],
+  paused:     ['in_transit'],
+  completed:  [],
+};
+
+const VALID_ACTOR_TYPES = ['human', 'system', 'agent'];
+
+export function isValidTrackingTransition(fromStatus, toStatus) {
+  const allowed = ALLOWED_TRANSITIONS[fromStatus];
+  return Array.isArray(allowed) && allowed.includes(toStatus);
+}
+
+export function getAllowedNextTrackingStatuses(currentStatus) {
+  return ALLOWED_TRANSITIONS[currentStatus] ?? [];
+}
+
+/**
+ * @param {object} params
+ * @param {object} params.supabase
+ * @param {string} params.tenantId
+ * @param {string} params.moveId
+ * @param {string} params.toStatus
+ * @param {{ id?: string, type: 'human' | 'system' | 'agent', context?: object }} params.actor
+ * @param {string} [params.note]
+ * @returns {Promise<object>} updated move row
+ */
+export async function transitionTrackingSession({
+  supabase, tenantId, moveId, toStatus,
+  actor, note,
+}) {
+  if (!actor || typeof actor !== 'object') {
+    throw new Error('actor is required');
+  }
+  if (!actor.type) {
+    throw new Error('actor.type is required (one of: human, system, agent)');
+  }
+  if (!VALID_ACTOR_TYPES.includes(actor.type)) {
+    throw new Error(`actor.type must be one of ${VALID_ACTOR_TYPES.join(', ')}; got: ${actor.type}`);
+  }
+
+  // 1. Read current
+  const { data: move, error: readErr } = await supabase
+    .from('order_container_moves')
+    .select('tracking_status, session_started_at, session_ended_at')
+    .eq('id', moveId)
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+  if (readErr) throw readErr;
+  if (!move) throw new Error(`Move not found: ${moveId} for tenant ${tenantId}`);
+
+  const fromStatus = move.tracking_status;
+
+  // 2. Validate
+  if (!isValidTrackingTransition(fromStatus, toStatus)) {
+    throw new Error(`Invalid transition: ${fromStatus} -> ${toStatus} for move ${moveId}`);
+  }
+
+  // 3. Update
+  const update = { tracking_status: toStatus };
+  const now = new Date().toISOString();
+  if (fromStatus === 'idle' && !move.session_started_at) {
+    update.session_started_at = now;
+  }
+  if (toStatus === 'completed' && !move.session_ended_at) {
+    update.session_ended_at = now;
+  }
+
+  const { data: updated, error: updErr } = await supabase
+    .from('order_container_moves')
+    .update(update)
+    .eq('id', moveId)
+    .eq('tenant_id', tenantId)
+    .select()
+    .single();
+  if (updErr) throw updErr;
+
+  // 4. History (log-and-continue)
+  try {
+    const { error: histErr } = await supabase
+      .from('move_tracking_session_history')
+      .insert({
+        tenant_id: tenantId,
+        move_id: moveId,
+        from_status: fromStatus,
+        to_status: toStatus,
+        actor_id: actor.id ?? null,
+        actor_type: actor.type,
+        actor_context: actor.context ?? null,
+        note: note ?? null,
+      });
+    if (histErr) {
+      console.error(`tracking history insert failed for ${moveId}:`, histErr.message);
+    }
+  } catch (e) {
+    console.error(`tracking history insert threw for ${moveId}:`, e?.message || e);
+  }
+
+  return updated;
+}

--- a/lib/settings-nav.js
+++ b/lib/settings-nav.js
@@ -75,6 +75,12 @@ export const SETTINGS_SECTIONS = [
     ],
   },
   {
+    group: 'Drivers',
+    items: [
+      { key: 'drivers', label: 'Drivers', href: '/settings/drivers', icon: Truck, requiredPermission: [PERMISSIONS.SETTINGS, PERMISSIONS.ALL] },
+    ],
+  },
+  {
     group: 'Operations',
     items: [
       { key: 'dispatcher_colors', label: 'Dispatcher Appearance', href: '/settings/dispatcher-colors', icon: Palette, requiredPermission: [PERMISSIONS.SETTINGS, PERMISSIONS.ALL] },

--- a/pages/api/cron/breadcrumb-retention.js
+++ b/pages/api/cron/breadcrumb-retention.js
@@ -1,0 +1,36 @@
+// pages/api/cron/breadcrumb-retention.js
+/**
+ * Daily cron: drops driver_location_pings rows older than 90 days.
+ * Audit history (event_status_history, tracking_session_history) is NOT touched —
+ * only telemetry is pruned.
+ */
+
+import { getServiceClient } from '../../../lib/tenant-api.js';
+import { cutoffIso } from '../../../lib/cron/breadcrumb-retention.js';
+
+function authOk(req) {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    if (process.env.NODE_ENV === 'production') return false;
+    return true;
+  }
+  const header = req.headers.authorization || '';
+  const token = header.replace(/^Bearer\s+/i, '').trim();
+  return token === expected;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  if (!authOk(req)) return res.status(401).json({ error: 'unauthorized' });
+
+  const svc = getServiceClient();
+  const cutoff = cutoffIso();
+
+  const { error, count } = await svc
+    .from('driver_location_pings')
+    .delete({ count: 'exact' })
+    .lt('recorded_at', cutoff);
+  if (error) return res.status(500).json({ error: error.message });
+
+  return res.status(200).json({ cutoff, deleted: count });
+}

--- a/pages/api/cron/stale-ping-pause.js
+++ b/pages/api/cron/stale-ping-pause.js
@@ -1,0 +1,63 @@
+// pages/api/cron/stale-ping-pause.js
+/**
+ * Vercel cron handler — every 60s.
+ * Finds in_transit moves that haven't pinged in 10+ minutes; flips to paused.
+ *
+ * Auth: shared CRON_SECRET (Bearer header).
+ */
+
+import { getServiceClient } from '../../../lib/tenant-api.js';
+import { findStaleMoves } from '../../../lib/cron/stale-ping-pause.js';
+import { transitionTrackingSession } from '../../../lib/routing/tracking-session-transition.js';
+
+function authOk(req) {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    if (process.env.NODE_ENV === 'production') return false;
+    return true;
+  }
+  const header = req.headers.authorization || '';
+  const token = header.replace(/^Bearer\s+/i, '').trim();
+  return token === expected;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  if (!authOk(req)) return res.status(401).json({ error: 'unauthorized' });
+
+  const svc = getServiceClient();
+  // Pull all in_transit moves with last_ping_at not null. v1 scans all tenants —
+  // bounded by typical at-most-few-hundred concurrent in_transit moves industry-
+  // wide. Add tenant scoping later if needed.
+  const { data: moves, error } = await svc
+    .from('order_container_moves')
+    .select('id, tenant_id, tracking_status, last_ping_at')
+    .eq('tracking_status', 'in_transit')
+    .not('last_ping_at', 'is', null);
+  if (error) return res.status(500).json({ error: error.message });
+
+  const stale = findStaleMoves(moves, Date.now());
+  let paused = 0;
+  let failed = 0;
+  for (const m of stale) {
+    try {
+      await transitionTrackingSession({
+        supabase: svc,
+        tenantId: m.tenant_id,
+        moveId: m.id,
+        toStatus: 'paused',
+        actor: {
+          type: 'system',
+          context: { source: 'system', reason: 'ping_timeout', last_ping_at: m.last_ping_at },
+        },
+        note: 'auto-paused: 10min idle',
+      });
+      paused++;
+    } catch (e) {
+      console.error(`stale-ping-pause failed for move ${m.id}:`, e?.message || e);
+      failed++;
+    }
+  }
+
+  return res.status(200).json({ scanned: moves?.length ?? 0, paused, failed });
+}

--- a/pages/api/driver/auth/change-password.js
+++ b/pages/api/driver/auth/change-password.js
@@ -1,0 +1,78 @@
+// pages/api/driver/auth/change-password.js
+/**
+ * POST /api/driver/auth/change-password
+ * Body: { old_password, new_password }
+ * Auth: requireDriver
+ * Returns: 204
+ *
+ * Sets password_set_at, clears password_must_change, bumps session_min_iat
+ * (invalidates the current JWT — client must log in again with new pwd).
+ */
+
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { verifyPassword, hashPassword } from '../../../../lib/driver-auth/utils.js';
+import { logTenantAction, getClientIp } from '../../../../lib/tenant-audit.js';
+
+const MIN_LENGTH = 8;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const { old_password, new_password } = req.body || {};
+  if (!old_password || !new_password) {
+    return res.status(400).json({ error: 'old_and_new_required' });
+  }
+  if (new_password.length < MIN_LENGTH) {
+    return res.status(400).json({ error: 'password_too_short', detail: `min ${MIN_LENGTH} chars` });
+  }
+  if (old_password === new_password) {
+    return res.status(400).json({ error: 'password_unchanged' });
+  }
+
+  const svc = getServiceClient();
+
+  // Re-fetch the password_hash since requireDriver doesn't include it in
+  // the SELECT (out of caution — middleware ctx shouldn't carry secrets).
+  const { data: driverWithHash } = await svc
+    .from('drivers')
+    .select('password_hash')
+    .eq('id', ctx.driverId)
+    .eq('tenant_id', ctx.tenantId)
+    .maybeSingle();
+
+  const ok = await verifyPassword(old_password, driverWithHash?.password_hash);
+  if (!ok) {
+    return res.status(401).json({ error: 'old_password_incorrect' });
+  }
+
+  const hash = await hashPassword(new_password);
+  const { error } = await svc
+    .from('drivers')
+    .update({
+      password_hash: hash,
+      password_set_at: new Date().toISOString(),
+      password_must_change: false,
+      session_min_iat: new Date().toISOString(),
+    })
+    .eq('id', ctx.driverId)
+    .eq('tenant_id', ctx.tenantId);
+  if (error) return res.status(500).json({ error: error.message });
+
+  await logTenantAction(svc, {
+    tenantId: ctx.tenantId,
+    userId: null,  // driver action, not tenant-user action
+    action: 'driver.password_changed',
+    entityType: 'driver',
+    entityId: ctx.driverId,
+    actorType: 'human',
+    agentMetadata: { source: 'driver_app', driver_id: ctx.driverId },
+    ipAddress: getClientIp(req),
+  });
+
+  return res.status(204).end();
+}

--- a/pages/api/driver/auth/login.js
+++ b/pages/api/driver/auth/login.js
@@ -1,0 +1,96 @@
+/**
+ * POST /api/driver/auth/login
+ * Body: { username, password }
+ * Returns: { token, driver: { id, name, username, must_change_password } }
+ *
+ * Throttle: 5 fails / 30min per username via driver_auth_attempts table.
+ */
+
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { verifyPassword, signDriverJWT } from '../../../../lib/driver-auth/utils.js';
+
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MINUTES = 30;
+
+function clientIp(req) {
+  return (
+    req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req.socket?.remoteAddress ||
+    null
+  );
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username_and_password_required' });
+  }
+
+  const svc = getServiceClient();
+  const ip = clientIp(req);
+  const since = new Date(Date.now() - LOCKOUT_MINUTES * 60 * 1000).toISOString();
+
+  // 1. Throttle check — count failed attempts for this username in window
+  const { data: recentFails } = await svc
+    .from('driver_auth_attempts')
+    .select('id')
+    .eq('username', username)
+    .eq('succeeded', false)
+    .gte('attempted_at', since);
+
+  if ((recentFails?.length ?? 0) >= MAX_ATTEMPTS) {
+    await svc.from('driver_auth_attempts').insert({
+      username, ip_address: ip, succeeded: false,
+    });
+    return res.status(429).json({
+      error: 'lockout',
+      detail: `Too many attempts. Try again in ${LOCKOUT_MINUTES} minutes.`,
+    });
+  }
+
+  // 2. Look up driver
+  const { data: driver } = await svc
+    .from('drivers')
+    .select('id, tenant_id, name, username, status, password_hash, password_must_change')
+    .eq('username', username)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (!driver || driver.status !== 'active') {
+    await svc.from('driver_auth_attempts').insert({
+      tenant_id: driver?.tenant_id ?? null, username, ip_address: ip, succeeded: false,
+    });
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+
+  // 3. Verify password
+  const ok = await verifyPassword(password, driver.password_hash);
+  if (!ok) {
+    await svc.from('driver_auth_attempts').insert({
+      tenant_id: driver.tenant_id, username, ip_address: ip, succeeded: false,
+    });
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+
+  // 4. Sign token
+  const token = signDriverJWT({ driverId: driver.id, tenantId: driver.tenant_id });
+
+  // 5. Record success
+  await svc.from('driver_auth_attempts').insert({
+    tenant_id: driver.tenant_id, username, ip_address: ip, succeeded: true,
+  });
+
+  return res.status(200).json({
+    token,
+    driver: {
+      id: driver.id,
+      name: driver.name,
+      username: driver.username,
+      must_change_password: driver.password_must_change,
+    },
+  });
+}

--- a/pages/api/driver/me/consent.js
+++ b/pages/api/driver/me/consent.js
@@ -1,0 +1,47 @@
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { CURRENT_CONSENT_VERSION } from '../../../../lib/driver-consent/version.js';
+import { logTenantAction, getClientIp } from '../../../../lib/tenant-audit.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const version = Number.isInteger(req.body?.version) ? req.body.version : CURRENT_CONSENT_VERSION;
+  if (version !== CURRENT_CONSENT_VERSION) {
+    return res.status(400).json({ error: 'consent_version_mismatch', current_version: CURRENT_CONSENT_VERSION });
+  }
+
+  const svc = getServiceClient();
+  const now = new Date().toISOString();
+  const { error } = await svc
+    .from('drivers')
+    .update({
+      tracking_consented_at: now,
+      tracking_consent_version: version,
+      tracking_revoked_at: null,
+    })
+    .eq('id', ctx.driverId)
+    .eq('tenant_id', ctx.tenantId);
+  if (error) return res.status(500).json({ error: error.message });
+
+  // Capture user-agent + IP for the audit record (legal evidence).
+  await logTenantAction(svc, {
+    tenantId: ctx.tenantId,
+    userId: null,
+    action: 'driver.consent_accepted',
+    entityType: 'driver',
+    entityId: ctx.driverId,
+    actorType: 'human',
+    agentMetadata: {
+      source: 'driver_app',
+      driver_id: ctx.driverId,
+      consent_version: version,
+      user_agent: req.headers['user-agent'] ?? null,
+    },
+    ipAddress: getClientIp(req),
+  });
+
+  return res.status(204).end();
+}

--- a/pages/api/driver/me/index.js
+++ b/pages/api/driver/me/index.js
@@ -1,0 +1,48 @@
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { isConsentValid, CURRENT_CONSENT_VERSION } from '../../../../lib/driver-consent/version.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+
+  // Look up tenant feature flag via the existing feature_flags + tenant_feature_flags pattern.
+  // Schema: feature_flags(id, name, ...), tenant_feature_flags(tenant_id, feature_flag_id, enabled)
+  const { data: tff } = await svc
+    .from('tenant_feature_flags')
+    .select('enabled, feature_flag:feature_flags!inner(name)')
+    .eq('tenant_id', ctx.tenantId)
+    .eq('feature_flag.name', 'move_tracking')
+    .maybeSingle();
+  const tenantFeatureEnabled = !!tff?.enabled;
+
+  const consentValid = isConsentValid(ctx.driver);
+  const trackingEligible =
+    tenantFeatureEnabled &&
+    ctx.driver.location_tracking_enabled &&
+    consentValid;
+
+  return res.status(200).json({
+    driver: {
+      id: ctx.driver.id,
+      name: ctx.driver.name,
+      username: ctx.driver.username,
+      must_change_password: ctx.driver.password_must_change,
+    },
+    consent: {
+      valid: consentValid,
+      consented_at: ctx.driver.tracking_consented_at,
+      revoked_at: ctx.driver.tracking_revoked_at,
+      version: ctx.driver.tracking_consent_version,
+      current_version: CURRENT_CONSENT_VERSION,
+    },
+    tracking: {
+      tenant_feature_enabled: tenantFeatureEnabled,
+      driver_toggle_enabled: ctx.driver.location_tracking_enabled,
+      eligible: trackingEligible,
+    },
+  });
+}

--- a/pages/api/driver/me/revoke-consent.js
+++ b/pages/api/driver/me/revoke-consent.js
@@ -1,0 +1,30 @@
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { logTenantAction, getClientIp } from '../../../../lib/tenant-audit.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const { error } = await svc
+    .from('drivers')
+    .update({ tracking_revoked_at: new Date().toISOString() })
+    .eq('id', ctx.driverId)
+    .eq('tenant_id', ctx.tenantId);
+  if (error) return res.status(500).json({ error: error.message });
+
+  await logTenantAction(svc, {
+    tenantId: ctx.tenantId,
+    userId: null,
+    action: 'driver.consent_revoked',
+    entityType: 'driver',
+    entityId: ctx.driverId,
+    actorType: 'human',
+    agentMetadata: { source: 'driver_app', driver_id: ctx.driverId },
+    ipAddress: getClientIp(req),
+  });
+
+  return res.status(204).end();
+}

--- a/pages/api/driver/moves/[id]/arrive.js
+++ b/pages/api/driver/moves/[id]/arrive.js
@@ -98,6 +98,6 @@ export default async function handler(req, res) {
     if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
     if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
     console.error('driver arrive error:', e);
-    return res.status(500).json({ error: 'internal_error', detail: e.message });
+    return res.status(500).json({ error: 'internal_error' });
   }
 }

--- a/pages/api/driver/moves/[id]/arrive.js
+++ b/pages/api/driver/moves/[id]/arrive.js
@@ -1,0 +1,103 @@
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../../lib/driver-auth/tracking-gates.js';
+import { applyDriverAction } from '../../../../../lib/routing/driver-action.js';
+
+const GPS_DRIFT_WARN_METERS = 500;
+
+function haversineMeters(lat1, lng1, lat2, lng2) {
+  const R = 6371000;
+  const toRad = (d) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { id: moveId } = req.query;
+  const { gpsPing, targetEventId, override_distance_warning } = req.body || {};
+  if (!gpsPing || typeof gpsPing.latitude !== 'number' || typeof gpsPing.longitude !== 'number' || !gpsPing.recorded_at) {
+    return res.status(400).json({ error: 'gpsPing_required' });
+  }
+  if (!targetEventId) return res.status(400).json({ error: 'targetEventId_required' });
+
+  // Look up event location for distance check.
+  // The event's lat/lng comes from its joined location (a customers row),
+  // which has columns latitude + longitude (per migration 036/manage org).
+  // If columns aren't present on customers, the GPS-drift check silently
+  // skips (gps_distance_at_arrival_m stays null).
+  const { data: event, error: eventErr } = await svc
+    .from('order_routing_events')
+    .select('id, location_id, location:customers(latitude, longitude)')
+    .eq('id', targetEventId)
+    .eq('tenant_id', ctx.tenantId)
+    .maybeSingle();
+  if (eventErr || !event) return res.status(404).json({ error: 'event_not_found' });
+
+  let gps_distance_at_arrival_m = null;
+  if (event.location?.latitude != null && event.location?.longitude != null) {
+    gps_distance_at_arrival_m = Math.round(
+      haversineMeters(gpsPing.latitude, gpsPing.longitude, event.location.latitude, event.location.longitude),
+    );
+    if (gps_distance_at_arrival_m > GPS_DRIFT_WARN_METERS && !override_distance_warning) {
+      return res.status(409).json({
+        error: 'gps_drift_warning',
+        gps_distance_m: gps_distance_at_arrival_m,
+        detail: 'You appear to be far from the location. Confirm and resend with override_distance_warning: true.',
+      });
+    }
+  }
+
+  try {
+    const result = await applyDriverAction({
+      supabase: svc, tenantId: ctx.tenantId, moveId, actionType: 'arrive',
+      driverId: ctx.driverId, targetEventId, gpsPing,
+    });
+    // Stamp the GPS distance into the event status history (most recent insert)
+    if (gps_distance_at_arrival_m != null) {
+      try {
+        const { data: histRows } = await svc
+          .from('order_routing_event_status_history')
+          .select('id, actor_context')
+          .eq('tenant_id', ctx.tenantId)
+          .eq('event_id', targetEventId)
+          .order('transitioned_at', { ascending: false })
+          .limit(1);
+        const row = histRows?.[0];
+        if (row) {
+          await svc
+            .from('order_routing_event_status_history')
+            .update({
+              actor_context: {
+                ...(row.actor_context ?? {}),
+                gps_distance_at_arrival_m,
+              },
+            })
+            .eq('id', row.id);
+        }
+      } catch (e) {
+        console.error('gps-distance audit update failed:', e?.message || e);
+      }
+    }
+    return res.status(200).json({ ...result, gps_distance_at_arrival_m });
+  } catch (e) {
+    if (e.message === 'ping_cap_reached') return res.status(429).json({ error: 'ping_cap_reached' });
+    if (e.message === 'move_unassigned') return res.status(409).json({ error: 'move_unassigned' });
+    if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
+    if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
+    console.error('driver arrive error:', e);
+    return res.status(500).json({ error: 'internal_error', detail: e.message });
+  }
+}

--- a/pages/api/driver/moves/[id]/depart.js
+++ b/pages/api/driver/moves/[id]/depart.js
@@ -33,6 +33,6 @@ export default async function handler(req, res) {
     if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
     if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
     console.error('driver depart error:', e);
-    return res.status(500).json({ error: 'internal_error', detail: e.message });
+    return res.status(500).json({ error: 'internal_error' });
   }
 }

--- a/pages/api/driver/moves/[id]/depart.js
+++ b/pages/api/driver/moves/[id]/depart.js
@@ -1,0 +1,38 @@
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../../lib/driver-auth/tracking-gates.js';
+import { applyDriverAction } from '../../../../../lib/routing/driver-action.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { id: moveId } = req.query;
+  const { gpsPing, targetEventId } = req.body || {};
+  if (!gpsPing || typeof gpsPing.latitude !== 'number' || typeof gpsPing.longitude !== 'number' || !gpsPing.recorded_at) {
+    return res.status(400).json({ error: 'gpsPing_required' });
+  }
+  if (!targetEventId) return res.status(400).json({ error: 'targetEventId_required' });
+
+  try {
+    const result = await applyDriverAction({
+      supabase: svc, tenantId: ctx.tenantId, moveId, actionType: 'depart',
+      driverId: ctx.driverId, targetEventId, gpsPing,
+    });
+    return res.status(200).json(result);
+  } catch (e) {
+    if (e.message === 'ping_cap_reached') return res.status(429).json({ error: 'ping_cap_reached' });
+    if (e.message === 'move_unassigned') return res.status(409).json({ error: 'move_unassigned' });
+    if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
+    if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
+    console.error('driver depart error:', e);
+    return res.status(500).json({ error: 'internal_error', detail: e.message });
+  }
+}

--- a/pages/api/driver/moves/[id]/index.js
+++ b/pages/api/driver/moves/[id]/index.js
@@ -1,0 +1,40 @@
+// pages/api/driver/moves/[id]/index.js
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const { id } = req.query;
+
+  const { data: move, error } = await svc
+    .from('order_container_moves')
+    .select(`
+      id, order_id, driver_id, status, tracking_status, scheduled_date, sort_order,
+      session_started_at, session_ended_at, last_ping_at, ping_count,
+      order:orders(
+        id, order_number, container_number, container_size, container_type, last_free_day, load_type
+      ),
+      events:order_routing_events(
+        id, sequence, event_type, event_status, location_id, location_name,
+        address, city, state, zip, scheduled_at, arrived_at, departed_at,
+        eta_arrival_at, eta_distance_remaining_miles
+      )
+    `)
+    .eq('id', id)
+    .eq('tenant_id', ctx.tenantId)
+    .maybeSingle();
+
+  if (error) return res.status(500).json({ error: error.message });
+  if (!move) return res.status(404).json({ error: 'move_not_found' });
+  if (move.driver_id !== ctx.driverId) return res.status(403).json({ error: 'forbidden' });
+
+  if (Array.isArray(move.events)) {
+    move.events.sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+  }
+
+  return res.status(200).json({ move });
+}

--- a/pages/api/driver/moves/[id]/ping.js
+++ b/pages/api/driver/moves/[id]/ping.js
@@ -107,16 +107,20 @@ export default async function handler(req, res) {
     }
   }
 
-  // 5. ETA recompute (if eligible: in_transit/paused, last update >90s ago, recompute count <50)
+  // 5. ETA recompute (if eligible: in_transit/paused, last ETA update >90s ago,
+  //    recompute count <50). Read the throttle gate from nextEvent.eta_updated_at,
+  //    NOT move.last_ping_at — last_ping_at was updated by step 3b above on every
+  //    ping, so using it here would mean elapsed≈0 and the throttle would never
+  //    fire, blowing through the recompute cap. eta_updated_at on the event row
+  //    is the authoritative "when did we last call Distance Matrix for this dest"
+  //    timestamp.
   let eta = null;
   if (move.tracking_status === 'in_transit' || move.tracking_status === 'paused') {
-    const lastEtaUpdate = move.last_ping_at ? new Date(move.last_ping_at).getTime() : 0;
-    const elapsed = Date.now() - lastEtaUpdate;
-    if (elapsed >= ETA_THROTTLE_MS && (move.eta_recompute_count ?? 0) < ETA_RECOMPUTE_CAP) {
+    if ((move.eta_recompute_count ?? 0) < ETA_RECOMPUTE_CAP) {
       // Find next pending event in this move
       const { data: nextEvent } = await svc
         .from('order_routing_events')
-        .select('id, location:customers(latitude, longitude)')
+        .select('id, eta_updated_at, location:customers(latitude, longitude)')
         .eq('tenant_id', ctx.tenantId)
         .eq('move_id', moveId)
         .eq('event_status', 'pending')
@@ -124,7 +128,17 @@ export default async function handler(req, res) {
         .limit(1)
         .maybeSingle();
 
-      if (nextEvent?.location?.latitude != null && nextEvent.location?.longitude != null) {
+      const lastEtaUpdate = nextEvent?.eta_updated_at
+        ? new Date(nextEvent.eta_updated_at).getTime()
+        : 0;
+      const elapsed = Date.now() - lastEtaUpdate;
+      const throttleOk = elapsed >= ETA_THROTTLE_MS;
+
+      if (
+        throttleOk &&
+        nextEvent?.location?.latitude != null &&
+        nextEvent.location?.longitude != null
+      ) {
         try {
           const result = await recomputeETA({
             origin: { lat: gpsPing.latitude, lng: gpsPing.longitude },
@@ -143,7 +157,8 @@ export default async function handler(req, res) {
                 eta_updated_at: new Date().toISOString(),
                 eta_distance_remaining_miles: result.distance_remaining_miles,
               })
-              .eq('id', nextEvent.id);
+              .eq('id', nextEvent.id)
+              .eq('tenant_id', ctx.tenantId);  // tenant guard — defense in depth
             if (!result.cached) {
               await svc
                 .from('order_container_moves')

--- a/pages/api/driver/moves/[id]/ping.js
+++ b/pages/api/driver/moves/[id]/ping.js
@@ -1,0 +1,164 @@
+/**
+ * POST /api/driver/moves/[id]/ping
+ * Body: { gpsPing: { latitude, longitude, recorded_at, accuracy_meters?, speed_mph?, heading?, battery_pct? } }
+ *
+ * Inserts a ping into driver_location_pings, denormalizes onto drivers.last_*,
+ * bumps move.last_ping_at + ping_count, recomputes ETA if eligible.
+ * Auto-resumes paused → in_transit on first ping after a pause.
+ */
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../../lib/driver-auth/tracking-gates.js';
+import { transitionTrackingSession } from '../../../../../lib/routing/tracking-session-transition.js';
+import { recomputeETA } from '../../../../../lib/google-maps/server-distance.js';
+
+const PING_CAP = 500;  // matches lib/routing/driver-action.js (raised from spec's 40)
+const ETA_THROTTLE_MS = 90 * 1000;
+const ETA_RECOMPUTE_CAP = 50;
+const PING_SOURCE = 'mobile_app';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { id: moveId } = req.query;
+  const { gpsPing } = req.body || {};
+  if (!gpsPing || typeof gpsPing.latitude !== 'number' || typeof gpsPing.longitude !== 'number' || !gpsPing.recorded_at) {
+    return res.status(400).json({ error: 'gpsPing_required' });
+  }
+
+  // 1. Read move + ownership
+  const { data: move, error: moveErr } = await svc
+    .from('order_container_moves')
+    .select('id, driver_id, tenant_id, tracking_status, ping_count, eta_recompute_count, last_ping_at')
+    .eq('id', moveId)
+    .eq('tenant_id', ctx.tenantId)
+    .maybeSingle();
+  if (moveErr || !move) return res.status(404).json({ error: 'move_not_found' });
+  if (move.driver_id !== ctx.driverId) return res.status(403).json({ error: 'forbidden' });
+
+  // 2. Cap
+  if ((move.ping_count ?? 0) >= PING_CAP) return res.status(429).json({ error: 'ping_cap_reached' });
+
+  // 3. Insert ping into driver_location_pings (with source='mobile_app')
+  const { data: pingRow, error: pingErr } = await svc
+    .from('driver_location_pings')
+    .insert({
+      tenant_id: ctx.tenantId, move_id: moveId, driver_id: ctx.driverId,
+      latitude: gpsPing.latitude, longitude: gpsPing.longitude,
+      accuracy_meters: gpsPing.accuracy_meters ?? null,
+      speed_mph: gpsPing.speed_mph ?? null,
+      heading: gpsPing.heading ?? null,
+      battery_pct: gpsPing.battery_pct ?? null,
+      source: PING_SOURCE,
+      recorded_at: gpsPing.recorded_at,
+    })
+    .select()
+    .single();
+  if (pingErr) return res.status(500).json({ error: pingErr.message });
+
+  // 3a. Denormalize onto drivers.last_* (where-is-driver-now).
+  //     Log-and-continue: a denorm failure shouldn't fail the whole ping path.
+  const { error: denormErr } = await svc
+    .from('drivers')
+    .update({
+      last_latitude: gpsPing.latitude,
+      last_longitude: gpsPing.longitude,
+      last_location_at: gpsPing.recorded_at,
+      last_location_source: PING_SOURCE,
+      last_speed_mph: gpsPing.speed_mph ?? null,
+      last_heading: gpsPing.heading ?? null,
+    })
+    .eq('id', ctx.driverId)
+    .eq('tenant_id', ctx.tenantId);
+  if (denormErr) {
+    console.error(`driver denorm update failed for ${ctx.driverId}:`, denormErr.message);
+  }
+
+  // 3b. Bump move's ping_count + last_ping_at (staleness-check column).
+  const { error: counterErr } = await svc
+    .from('order_container_moves')
+    .update({
+      ping_count: (move.ping_count ?? 0) + 1,
+      last_ping_at: gpsPing.recorded_at,
+    })
+    .eq('id', moveId)
+    .eq('tenant_id', ctx.tenantId);
+  if (counterErr) {
+    console.error(`move counter update failed for ${moveId}:`, counterErr.message);
+  }
+
+  // 4. Auto-resume paused → in_transit
+  if (move.tracking_status === 'paused') {
+    try {
+      await transitionTrackingSession({
+        supabase: svc, tenantId: ctx.tenantId, moveId, toStatus: 'in_transit',
+        actor: { id: ctx.driverId, type: 'human', context: { source: 'driver_app', resumed_from_pause: true, ping_id: pingRow.id } },
+      });
+    } catch (e) {
+      console.error('auto-resume failed:', e?.message || e);
+    }
+  }
+
+  // 5. ETA recompute (if eligible: in_transit/paused, last update >90s ago, recompute count <50)
+  let eta = null;
+  if (move.tracking_status === 'in_transit' || move.tracking_status === 'paused') {
+    const lastEtaUpdate = move.last_ping_at ? new Date(move.last_ping_at).getTime() : 0;
+    const elapsed = Date.now() - lastEtaUpdate;
+    if (elapsed >= ETA_THROTTLE_MS && (move.eta_recompute_count ?? 0) < ETA_RECOMPUTE_CAP) {
+      // Find next pending event in this move
+      const { data: nextEvent } = await svc
+        .from('order_routing_events')
+        .select('id, location:customers(latitude, longitude)')
+        .eq('tenant_id', ctx.tenantId)
+        .eq('move_id', moveId)
+        .eq('event_status', 'pending')
+        .order('sequence', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+      if (nextEvent?.location?.latitude != null && nextEvent.location?.longitude != null) {
+        try {
+          const result = await recomputeETA({
+            origin: { lat: gpsPing.latitude, lng: gpsPing.longitude },
+            destination: {
+              lat: nextEvent.location.latitude,
+              lng: nextEvent.location.longitude,
+              eventId: nextEvent.id,
+            },
+            recomputeCount: move.eta_recompute_count ?? 0,
+          });
+          if (!result.skipped) {
+            await svc
+              .from('order_routing_events')
+              .update({
+                eta_arrival_at: result.eta_arrival_at,
+                eta_updated_at: new Date().toISOString(),
+                eta_distance_remaining_miles: result.distance_remaining_miles,
+              })
+              .eq('id', nextEvent.id);
+            if (!result.cached) {
+              await svc
+                .from('order_container_moves')
+                .update({ eta_recompute_count: (move.eta_recompute_count ?? 0) + 1 })
+                .eq('id', moveId)
+                .eq('tenant_id', ctx.tenantId);
+            }
+            eta = result;
+          }
+        } catch (e) {
+          console.error('ETA recompute failed:', e?.message || e);
+        }
+      }
+    }
+  }
+
+  return res.status(200).json({ ping_id: pingRow.id, eta });
+}

--- a/pages/api/driver/moves/[id]/start.js
+++ b/pages/api/driver/moves/[id]/start.js
@@ -1,0 +1,37 @@
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../../lib/driver-auth/tracking-gates.js';
+import { applyDriverAction } from '../../../../../lib/routing/driver-action.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { id: moveId } = req.query;
+  const { gpsPing } = req.body || {};
+  if (!gpsPing || typeof gpsPing.latitude !== 'number' || typeof gpsPing.longitude !== 'number' || !gpsPing.recorded_at) {
+    return res.status(400).json({ error: 'gpsPing_required', detail: 'latitude/longitude/recorded_at required' });
+  }
+
+  try {
+    const result = await applyDriverAction({
+      supabase: svc, tenantId: ctx.tenantId, moveId, actionType: 'start',
+      driverId: ctx.driverId, gpsPing,
+    });
+    return res.status(200).json(result);
+  } catch (e) {
+    if (e.message === 'ping_cap_reached') return res.status(429).json({ error: 'ping_cap_reached' });
+    if (e.message === 'move_unassigned') return res.status(409).json({ error: 'move_unassigned' });
+    if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
+    if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
+    console.error('driver start error:', e);
+    return res.status(500).json({ error: 'internal_error', detail: e.message });
+  }
+}

--- a/pages/api/driver/moves/[id]/start.js
+++ b/pages/api/driver/moves/[id]/start.js
@@ -32,6 +32,6 @@ export default async function handler(req, res) {
     if (e.message?.startsWith('forbidden')) return res.status(403).json({ error: 'forbidden' });
     if (e.message?.startsWith('Invalid transition')) return res.status(409).json({ error: 'invalid_transition', detail: e.message });
     console.error('driver start error:', e);
-    return res.status(500).json({ error: 'internal_error', detail: e.message });
+    return res.status(500).json({ error: 'internal_error' });
   }
 }

--- a/pages/api/driver/moves/[id]/undo.js
+++ b/pages/api/driver/moves/[id]/undo.js
@@ -1,0 +1,122 @@
+/**
+ * Undoes the driver's most recent transition on this move.
+ * Rules:
+ *   - Within 2 minutes of the original action
+ *   - No dispatcher_ui-source history row exists after the original tap
+ *   - Idempotent: running undo twice is rejected (no transitions to undo)
+ */
+import { requireDriver } from '../../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../../lib/driver-auth/tracking-gates.js';
+
+const UNDO_WINDOW_MS = 2 * 60 * 1000;
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { id: moveId } = req.query;
+
+  // 1. Verify move ownership
+  const { data: move, error: moveErr } = await svc
+    .from('order_container_moves')
+    .select('id, driver_id, tracking_status')
+    .eq('id', moveId)
+    .eq('tenant_id', ctx.tenantId)
+    .maybeSingle();
+  if (moveErr || !move) return res.status(404).json({ error: 'move_not_found' });
+  if (move.driver_id !== ctx.driverId) return res.status(403).json({ error: 'forbidden' });
+
+  // 2. Find most recent driver-app event-status transition on any event of this move,
+  //    within undo window, with no dispatcher override after.
+  const cutoffIso = new Date(Date.now() - UNDO_WINDOW_MS).toISOString();
+  const { data: histRows } = await svc
+    .from('order_routing_event_status_history')
+    .select('id, event_id, from_status, to_status, transitioned_at, actor_context')
+    .eq('tenant_id', ctx.tenantId)
+    .gte('transitioned_at', cutoffIso)
+    .order('transitioned_at', { ascending: false });
+
+  // Filter by events in this move
+  const { data: moveEvents } = await svc
+    .from('order_routing_events')
+    .select('id')
+    .eq('tenant_id', ctx.tenantId)
+    .eq('move_id', moveId);
+  const moveEventIds = new Set((moveEvents ?? []).map((e) => e.id));
+
+  let target = null;
+  for (const row of histRows ?? []) {
+    if (!moveEventIds.has(row.event_id)) continue;
+    if (row.actor_context?.source !== 'driver_app') continue;
+    target = row;
+    break;
+  }
+  if (!target) return res.status(409).json({ error: 'no_undo_target' });
+
+  // 3. Reject if a dispatcher_ui row exists after the target on the same event
+  const { data: laterDispatcher } = await svc
+    .from('order_routing_event_status_history')
+    .select('id, actor_context')
+    .eq('tenant_id', ctx.tenantId)
+    .eq('event_id', target.event_id)
+    .gt('transitioned_at', target.transitioned_at);
+  if ((laterDispatcher ?? []).some((r) => r.actor_context?.source === 'dispatcher_ui')) {
+    return res.status(409).json({ error: 'dispatcher_overrode' });
+  }
+
+  // 4. Reverse transition (direct revert; bypasses state machine).
+  const update = { event_status: target.from_status };
+  if (target.to_status === 'arrived') update.arrived_at = null;
+  if (target.to_status === 'departed') update.departed_at = null;
+  const { error: evUpdErr } = await svc
+    .from('order_routing_events')
+    .update(update)
+    .eq('id', target.event_id)
+    .eq('tenant_id', ctx.tenantId);
+  if (evUpdErr) return res.status(500).json({ error: evUpdErr.message });
+
+  await svc.from('order_routing_event_status_history').insert({
+    tenant_id: ctx.tenantId,
+    event_id: target.event_id,
+    from_status: target.to_status,
+    to_status: target.from_status,
+    actor_id: ctx.driverId,
+    actor_type: 'human',
+    actor_context: { source: 'driver_app', undo: true, original_history_id: target.id },
+    note: 'driver undo',
+  });
+
+  // 5. Reverse the tracking_status transition if needed.
+  let trackingFrom = move.tracking_status;
+  let trackingTo = null;
+  if (target.to_status === 'arrived' && trackingFrom === 'on_site') trackingTo = 'in_transit';
+  if (target.to_status === 'departed' && (trackingFrom === 'in_transit' || trackingFrom === 'completed')) trackingTo = 'on_site';
+
+  if (trackingTo) {
+    await svc
+      .from('order_container_moves')
+      .update({ tracking_status: trackingTo, session_ended_at: null })
+      .eq('id', moveId)
+      .eq('tenant_id', ctx.tenantId);
+    await svc.from('move_tracking_session_history').insert({
+      tenant_id: ctx.tenantId,
+      move_id: moveId,
+      from_status: trackingFrom,
+      to_status: trackingTo,
+      actor_id: ctx.driverId,
+      actor_type: 'human',
+      actor_context: { source: 'driver_app', undo: true, original_history_id: target.id },
+      note: 'driver undo',
+    });
+  }
+
+  return res.status(200).json({ undone: { event_id: target.event_id, from: target.to_status, to: target.from_status } });
+}

--- a/pages/api/driver/moves/today.js
+++ b/pages/api/driver/moves/today.js
@@ -1,0 +1,49 @@
+// pages/api/driver/moves/today.js
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+
+  // Today defined as scheduled_date = today (driver's local "today" — for v1
+  // we use server-local date since drivers operate in tenant timezone; can
+  // pass ?date=YYYY-MM-DD to override).
+  const dateParam = req.query.date;
+  const today = dateParam || new Date().toISOString().slice(0, 10);
+
+  const { data: moves, error } = await svc
+    .from('order_container_moves')
+    .select(`
+      id, order_id, status, tracking_status, scheduled_date, sort_order,
+      session_started_at, session_ended_at, last_ping_at, ping_count,
+      order:orders(
+        id, order_number, container_number, container_size, container_type, last_free_day,
+        load_type
+      ),
+      events:order_routing_events(
+        id, sequence, event_type, event_status, location_id, location_name,
+        address, city, state, zip, scheduled_at, arrived_at, departed_at,
+        eta_arrival_at, eta_distance_remaining_miles
+      )
+    `)
+    .eq('tenant_id', ctx.tenantId)
+    .eq('driver_id', ctx.driverId)
+    .eq('scheduled_date', today)
+    .neq('status', 'cancelled')
+    .order('sort_order', { ascending: true });
+
+  if (error) return res.status(500).json({ error: error.message });
+
+  // Sort events per move
+  for (const m of moves ?? []) {
+    if (Array.isArray(m.events)) {
+      m.events.sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    }
+  }
+
+  return res.status(200).json({ date: today, moves: moves ?? [] });
+}

--- a/pages/api/driver/pings/batch.js
+++ b/pages/api/driver/pings/batch.js
@@ -32,9 +32,33 @@ export default async function handler(req, res) {
   if (items.length === 0) return res.status(200).json({ accepted: 0 });
   if (items.length > MAX_BATCH_SIZE) return res.status(413).json({ error: 'batch_too_large' });
 
+  // Move-ownership pre-check: a driver may only post pings for moves they
+  // own. Without this, a driver could poison another driver's ping_count
+  // (triggering false stale-ping pause) or seed bogus breadcrumb pings on
+  // someone else's move. Pre-fetch the set of move IDs assigned to this
+  // driver and filter the batch — items pointing at unowned/unknown moves
+  // are silently dropped from the insert + reflected in the response.
+  const requestedMoveIds = [...new Set(items.map((i) => i.moveId).filter(Boolean))];
+  const ownedMoveIds = new Set();
+  if (requestedMoveIds.length > 0) {
+    const { data: ownedMoves, error: ownedErr } = await svc
+      .from('order_container_moves')
+      .select('id')
+      .eq('tenant_id', ctx.tenantId)
+      .eq('driver_id', ctx.driverId)
+      .in('id', requestedMoveIds);
+    if (ownedErr) return res.status(500).json({ error: 'lookup_failed' });
+    for (const m of ownedMoves ?? []) ownedMoveIds.add(m.id);
+  }
+  const validItems = items.filter((i) => ownedMoveIds.has(i.moveId));
+  const rejectedCount = items.length - validItems.length;
+  if (validItems.length === 0) {
+    return res.status(200).json({ accepted: 0, rejected: rejectedCount });
+  }
+
   // Single multi-row INSERT (atomic enough for v1 — partial failures surface
   // as a single error and we accept that limitation).
-  const rows = items.map((item) => ({
+  const rows = validItems.map((item) => ({
     tenant_id: ctx.tenantId,
     move_id: item.moveId,
     driver_id: ctx.driverId,
@@ -48,12 +72,16 @@ export default async function handler(req, res) {
     recorded_at: item.gpsPing.recorded_at,
   }));
   const { error } = await svc.from('driver_location_pings').insert(rows);
-  if (error) return res.status(500).json({ error: error.message });
+  if (error) {
+    console.error('batch ping insert failed:', error.message);
+    return res.status(500).json({ error: 'insert_failed' });
+  }
 
   // Bump last_ping_at + ping_count per move (best-effort, group by move_id and
   // pick latest recorded_at). v1: scan + update from highest recorded_at.
+  // Only iterates validItems so unowned moves are never touched.
   const byMove = new Map();
-  for (const item of items) {
+  for (const item of validItems) {
     const cur = byMove.get(item.moveId);
     if (!cur || item.gpsPing.recorded_at > cur.recorded_at) {
       byMove.set(item.moveId, {
@@ -86,8 +114,9 @@ export default async function handler(req, res) {
   }
 
   // Update driver's last_* from the absolute-latest ping in the batch
+  // (only over validated items)
   let latestPing = null;
-  for (const item of items) {
+  for (const item of validItems) {
     if (!latestPing || item.gpsPing.recorded_at > latestPing.recorded_at) {
       latestPing = item.gpsPing;
     }
@@ -107,5 +136,5 @@ export default async function handler(req, res) {
       .eq('tenant_id', ctx.tenantId);
   }
 
-  return res.status(200).json({ accepted: items.length });
+  return res.status(200).json({ accepted: validItems.length, rejected: rejectedCount });
 }

--- a/pages/api/driver/pings/batch.js
+++ b/pages/api/driver/pings/batch.js
@@ -1,0 +1,111 @@
+/**
+ * POST /api/driver/pings/batch
+ * Body: { items: [{ moveId, gpsPing }, ...] }   max 100
+ *
+ * For offline-queue flush. Each insert preserves recorded_at; received_at
+ * defaults to server now(). Skips ping_count cap enforcement on individual
+ * items (the queue itself caps at 100, and a flush of 100 mostly-offline
+ * pings is legitimate). Does NOT recompute ETA per item — cost gating.
+ *
+ * Returns: { accepted: N }
+ */
+import { requireDriver } from '../../../../lib/driver-auth/middleware.js';
+import { getServiceClient } from '../../../../lib/tenant-api.js';
+import { checkTrackingGates } from '../../../../lib/driver-auth/tracking-gates.js';
+
+const MAX_BATCH_SIZE = 100;
+const PING_SOURCE = 'mobile_app';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const ctx = await requireDriver(req, res);
+  if (!ctx) return;
+
+  const svc = getServiceClient();
+  const gateFail = await checkTrackingGates({
+    supabase: svc, tenantId: ctx.tenantId, driver: ctx.driver,
+  });
+  if (gateFail) return res.status(gateFail.status).json({ error: gateFail.error });
+
+  const { items } = req.body || {};
+  if (!Array.isArray(items)) return res.status(400).json({ error: 'items_array_required' });
+  if (items.length === 0) return res.status(200).json({ accepted: 0 });
+  if (items.length > MAX_BATCH_SIZE) return res.status(413).json({ error: 'batch_too_large' });
+
+  // Single multi-row INSERT (atomic enough for v1 — partial failures surface
+  // as a single error and we accept that limitation).
+  const rows = items.map((item) => ({
+    tenant_id: ctx.tenantId,
+    move_id: item.moveId,
+    driver_id: ctx.driverId,
+    latitude: item.gpsPing.latitude,
+    longitude: item.gpsPing.longitude,
+    accuracy_meters: item.gpsPing.accuracy_meters ?? null,
+    speed_mph: item.gpsPing.speed_mph ?? null,
+    heading: item.gpsPing.heading ?? null,
+    battery_pct: item.gpsPing.battery_pct ?? null,
+    source: PING_SOURCE,
+    recorded_at: item.gpsPing.recorded_at,
+  }));
+  const { error } = await svc.from('driver_location_pings').insert(rows);
+  if (error) return res.status(500).json({ error: error.message });
+
+  // Bump last_ping_at + ping_count per move (best-effort, group by move_id and
+  // pick latest recorded_at). v1: scan + update from highest recorded_at.
+  const byMove = new Map();
+  for (const item of items) {
+    const cur = byMove.get(item.moveId);
+    if (!cur || item.gpsPing.recorded_at > cur.recorded_at) {
+      byMove.set(item.moveId, {
+        recorded_at: item.gpsPing.recorded_at,
+        latitude: item.gpsPing.latitude,
+        longitude: item.gpsPing.longitude,
+        count_in_batch: (cur?.count_in_batch ?? 0) + 1,
+      });
+    } else {
+      byMove.set(item.moveId, { ...cur, count_in_batch: (cur?.count_in_batch ?? 0) + 1 });
+    }
+  }
+  for (const [moveId, latest] of byMove.entries()) {
+    const { data: cur } = await svc
+      .from('order_container_moves')
+      .select('ping_count, last_ping_at')
+      .eq('id', moveId)
+      .eq('tenant_id', ctx.tenantId)
+      .maybeSingle();
+    if (!cur) continue;
+    const update = { ping_count: (cur.ping_count ?? 0) + latest.count_in_batch };
+    if (!cur.last_ping_at || latest.recorded_at > cur.last_ping_at) {
+      update.last_ping_at = latest.recorded_at;
+    }
+    await svc
+      .from('order_container_moves')
+      .update(update)
+      .eq('id', moveId)
+      .eq('tenant_id', ctx.tenantId);
+  }
+
+  // Update driver's last_* from the absolute-latest ping in the batch
+  let latestPing = null;
+  for (const item of items) {
+    if (!latestPing || item.gpsPing.recorded_at > latestPing.recorded_at) {
+      latestPing = item.gpsPing;
+    }
+  }
+  if (latestPing) {
+    await svc
+      .from('drivers')
+      .update({
+        last_latitude: latestPing.latitude,
+        last_longitude: latestPing.longitude,
+        last_location_at: latestPing.recorded_at,
+        last_location_source: PING_SOURCE,
+        last_speed_mph: latestPing.speed_mph ?? null,
+        last_heading: latestPing.heading ?? null,
+      })
+      .eq('id', ctx.driverId)
+      .eq('tenant_id', ctx.tenantId);
+  }
+
+  return res.status(200).json({ accepted: items.length });
+}

--- a/pages/api/tenant/dispatcher/planner/index.js
+++ b/pages/api/tenant/dispatcher/planner/index.js
@@ -68,7 +68,7 @@ export default async function handler(req, res) {
       id, tenant_id, order_id, sequence, move_type,
       driver_id, truck_id, chassis_id,
       status, started_at, completed_at, scheduled_date, sort_order,
-      assigned_at,
+      assigned_at, tracking_status, last_ping_at, session_started_at, ping_count,
       order:orders!order_container_moves_order_id_fkey(
         id, order_number, container_number, container_size, container_type,
         last_free_day, container_at_port, empty_ready_for_return_at, branch_id,

--- a/pages/api/tenant/drivers/[id]/index.js
+++ b/pages/api/tenant/drivers/[id]/index.js
@@ -23,7 +23,7 @@ const EDITABLE_FIELDS = [
   'endorsements',
   'pay_type', 'pay_rate_cents', 'pay_percentage', 'hst_pct',
   'disable_driver_pay', 'hide_settlements',
-  'mobile_permissions',
+  'mobile_permissions', 'location_tracking_enabled',
   'status', 'notes', 'branch_id',
 ];
 

--- a/pages/api/tenant/drivers/[id]/kill-session.js
+++ b/pages/api/tenant/drivers/[id]/kill-session.js
@@ -1,0 +1,37 @@
+import {
+  requireTenantUser, requirePermission, getServiceClient,
+} from '../../../../../lib/tenant-api.js';
+import { PERMISSIONS } from '../../../../../lib/permissions.js';
+import { logTenantAction, getClientIp } from '../../../../../lib/tenant-audit.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+  const ctx = await requireTenantUser(req, res);
+  if (!ctx) return;
+  if (!requirePermission(ctx, [PERMISSIONS.DISPATCHING, PERMISSIONS.ALL], res)) return;
+
+  const { id } = req.query;
+  const svc = getServiceClient();
+
+  const { error } = await svc
+    .from('drivers')
+    .update({ session_min_iat: new Date().toISOString() })
+    .eq('id', id)
+    .eq('tenant_id', ctx.tenantId)
+    .is('deleted_at', null);
+  if (error) return res.status(500).json({ error: error.message });
+
+  await logTenantAction(svc, {
+    tenantId: ctx.tenantId,
+    userId: ctx.userId,
+    action: 'driver.session_killed',
+    entityType: 'driver',
+    entityId: id,
+    actorType: 'human',
+    ipAddress: getClientIp(req),
+  });
+
+  return res.status(204).end();
+}

--- a/pages/api/tenant/drivers/[id]/reset-password.js
+++ b/pages/api/tenant/drivers/[id]/reset-password.js
@@ -1,0 +1,46 @@
+import {
+  requireTenantUser, requirePermission, getServiceClient,
+} from '../../../../../lib/tenant-api.js';
+import { PERMISSIONS } from '../../../../../lib/permissions.js';
+import { logTenantAction, getClientIp } from '../../../../../lib/tenant-audit.js';
+import { hashPassword, generateTempPassword } from '../../../../../lib/driver-auth/utils.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'method_not_allowed' });
+  }
+  const ctx = await requireTenantUser(req, res);
+  if (!ctx) return;
+  if (!requirePermission(ctx, [PERMISSIONS.DISPATCHING, PERMISSIONS.ALL], res)) return;
+
+  const { id } = req.query;
+  const tempPassword = req.body?.temp_password ?? generateTempPassword();
+
+  const svc = getServiceClient();
+  const hash = await hashPassword(tempPassword);
+
+  const { error } = await svc
+    .from('drivers')
+    .update({
+      password_hash: hash,
+      password_set_at: new Date().toISOString(),
+      password_must_change: true,
+      session_min_iat: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', ctx.tenantId)
+    .is('deleted_at', null);
+  if (error) return res.status(500).json({ error: error.message });
+
+  await logTenantAction(svc, {
+    tenantId: ctx.tenantId,
+    userId: ctx.userId,
+    action: 'driver.password_reset',
+    entityType: 'driver',
+    entityId: id,
+    actorType: 'human',
+    ipAddress: getClientIp(req),
+  });
+
+  return res.status(200).json({ temp_password: tempPassword });
+}

--- a/pages/api/tenant/feature-flags/move-tracking.js
+++ b/pages/api/tenant/feature-flags/move-tracking.js
@@ -1,0 +1,89 @@
+/**
+ * GET  /api/tenant/feature-flags/move-tracking → { enabled: boolean }
+ * PUT  /api/tenant/feature-flags/move-tracking → 204
+ *   Body: { enabled: boolean }
+ *
+ * Reads/writes the per-tenant move_tracking feature flag in the
+ * tenant_feature_flags table. Joins through feature_flags.name.
+ *
+ * NOTE: tenant_feature_flags has a 3-column unique constraint:
+ *   UNIQUE (tenant_id, feature_flag_id, user_id)
+ * Tenant-level flags always use user_id = NULL.
+ *
+ * Auth: requireTenantUser + SETTINGS permission (matches other tenant-admin
+ * settings endpoints).
+ */
+
+import {
+  requireTenantUser,
+  requirePermission,
+  getServiceClient,
+} from '../../../../lib/tenant-api';
+import { PERMISSIONS } from '../../../../lib/permissions';
+import { logTenantAction, getClientIp } from '../../../../lib/tenant-audit';
+
+const FLAG_NAME = 'move_tracking';
+
+async function getFlagId(svc) {
+  const { data: ff } = await svc
+    .from('feature_flags')
+    .select('id')
+    .eq('name', FLAG_NAME)
+    .maybeSingle();
+  return ff?.id ?? null;
+}
+
+export default async function handler(req, res) {
+  const ctx = await requireTenantUser(req, res);
+  if (!ctx) return;
+  if (!requirePermission(ctx, [PERMISSIONS.SETTINGS, PERMISSIONS.ALL], res)) return;
+
+  const svc = getServiceClient();
+
+  if (req.method === 'GET') {
+    const { data: tff } = await svc
+      .from('tenant_feature_flags')
+      .select('enabled, feature_flag:feature_flags!inner(name)')
+      .eq('tenant_id', ctx.tenantId)
+      .eq('feature_flag.name', FLAG_NAME)
+      .is('user_id', null)
+      .maybeSingle();
+    return res.status(200).json({ enabled: !!tff?.enabled });
+  }
+
+  if (req.method === 'PUT') {
+    const enabled = !!req.body?.enabled;
+    const flagId = await getFlagId(svc);
+    if (!flagId) {
+      return res.status(500).json({
+        error: 'feature_flag_not_registered',
+        detail: `${FLAG_NAME} flag missing from feature_flags table`,
+      });
+    }
+
+    // Upsert the tenant-level row (user_id = NULL).
+    // The unique constraint is (tenant_id, feature_flag_id, user_id).
+    const { error } = await svc
+      .from('tenant_feature_flags')
+      .upsert(
+        { tenant_id: ctx.tenantId, feature_flag_id: flagId, enabled, user_id: null },
+        { onConflict: 'tenant_id,feature_flag_id,user_id' }
+      );
+    if (error) return res.status(500).json({ error: error.message });
+
+    await logTenantAction(svc, {
+      tenantId: ctx.tenantId,
+      userId: ctx.userId,
+      action: enabled ? 'tenant.feature_enabled' : 'tenant.feature_disabled',
+      entityType: 'tenant_feature_flag',
+      entityId: ctx.tenantId,
+      newValues: { feature_flag: FLAG_NAME, enabled },
+      actorType: 'human',
+      ipAddress: getClientIp(req),
+    });
+
+    return res.status(204).end();
+  }
+
+  return res.status(405).json({ error: 'method_not_allowed' });
+}

--- a/pages/api/tenant/loads/[id]/routing/events/[eventId].js
+++ b/pages/api/tenant/loads/[id]/routing/events/[eventId].js
@@ -190,7 +190,8 @@ export default async function handler(req, res) {
         if (e.message?.startsWith('Invalid transition')) {
           return res.status(409).json({ error: 'invalid_transition', detail: e.message });
         }
-        return res.status(500).json({ error: e.message });
+        console.error('dispatcher override error:', e);
+        return res.status(500).json({ error: 'override_failed' });
       }
     }
 

--- a/pages/api/tenant/loads/[id]/routing/events/[eventId].js
+++ b/pages/api/tenant/loads/[id]/routing/events/[eventId].js
@@ -96,6 +96,128 @@ export default async function handler(req, res) {
       .eq('id', eventId)
       .maybeSingle();
 
+    // ====== Dispatcher override flow ======
+    //
+    // When dispatcher_override_driver: true is in the body, this is an explicit
+    // override of a driver-tap transition. Routes through transitionEventStatus
+    // (FU-082-aware) and captures the original driver record in actor_context.
+    //
+    // For toStatus='pending', the state machine doesn't allow arrived→pending,
+    // so we do a direct revert (mirrors the undo path in
+    // /api/driver/moves/[id]/undo.js).
+    if (req.body?.dispatcher_override_driver === true) {
+      const toStatus = req.body.to_status;
+      const overrideTimestamp = req.body.override_timestamp;  // ISO string, optional
+      const reason = req.body.reason ?? null;
+
+      if (!['arrived', 'departed', 'pending', 'skipped'].includes(toStatus)) {
+        return res.status(400).json({ error: 'invalid_to_status' });
+      }
+
+      // Find driver-app history row(s) we're overriding to capture original_*
+      const { data: driverHistory } = await svc
+        .from('order_routing_event_status_history')
+        .select('id, transitioned_at, actor_context')
+        .eq('tenant_id', ctx.tenantId)
+        .eq('event_id', eventId)
+        .eq('actor_type', 'human')
+        .order('transitioned_at', { ascending: false })
+        .limit(5);
+      const driverRow = (driverHistory || []).find((r) => r.actor_context?.source === 'driver_app');
+
+      try {
+        // For pending revert (rare — clear timestamp + return to pending), direct revert.
+        if (toStatus === 'pending') {
+          const update = { event_status: 'pending', arrived_at: null, departed_at: null };
+          const { error: updErr } = await svc
+            .from('order_routing_events')
+            .update(update)
+            .eq('id', eventId)
+            .eq('tenant_id', ctx.tenantId);
+          if (updErr) return res.status(500).json({ error: updErr.message });
+          await svc.from('order_routing_event_status_history').insert({
+            tenant_id: ctx.tenantId,
+            event_id: eventId,
+            from_status: oldEvent?.event_status ?? null,
+            to_status: 'pending',
+            actor_id: ctx.userId,
+            actor_type: 'human',
+            actor_context: {
+              source: 'dispatcher_ui',
+              overrode_driver: !!driverRow,
+              original_driver_timestamp: driverRow ? driverRow.transitioned_at : null,
+              original_ping_id: driverRow?.actor_context?.ping_id ?? null,
+              reason,
+            },
+            note: reason || 'dispatcher revert',
+          });
+          return res.status(200).json({ event_id: eventId, to_status: 'pending' });
+        }
+
+        // For arrived/departed/skipped — go through the helper.
+        const updated = await transitionEventStatus({
+          supabase: svc,
+          tenantId: ctx.tenantId,
+          eventId,
+          toStatus,
+          actor: {
+            id: ctx.userId,
+            type: 'human',
+            context: {
+              source: 'dispatcher_ui',
+              overrode_driver: !!driverRow,
+              original_driver_timestamp: driverRow ? driverRow.transitioned_at : null,
+              original_ping_id: driverRow?.actor_context?.ping_id ?? null,
+              reason,
+            },
+          },
+          note: reason || 'dispatcher override',
+        });
+
+        // Override the timestamp set by the helper if dispatcher chose a specific
+        // value (helper used now() — this lets the dispatcher correct the time).
+        if (overrideTimestamp) {
+          const colName = toStatus === 'arrived' ? 'arrived_at' : 'departed_at';
+          await svc
+            .from('order_routing_events')
+            .update({ [colName]: overrideTimestamp })
+            .eq('id', eventId)
+            .eq('tenant_id', ctx.tenantId);
+        }
+
+        return res.status(200).json({ event: updated });
+      } catch (e) {
+        if (e.message?.startsWith('Invalid transition')) {
+          return res.status(409).json({ error: 'invalid_transition', detail: e.message });
+        }
+        return res.status(500).json({ error: e.message });
+      }
+    }
+
+    // ====== Implicit-override rejection ======
+    //
+    // If the body is editing arrived_at or departed_at via the EDITABLE_FIELDS
+    // whitelist AND the event already has a driver-app history row, reject —
+    // the dispatcher must use the explicit dispatcher_override_driver flow.
+    const directTimestampEdit =
+      req.body.arrived_at !== undefined || req.body.departed_at !== undefined;
+    if (directTimestampEdit) {
+      const { data: driverHist } = await svc
+        .from('order_routing_event_status_history')
+        .select('id')
+        .eq('tenant_id', ctx.tenantId)
+        .eq('event_id', eventId)
+        .eq('actor_type', 'human')
+        .filter('actor_context->>source', 'eq', 'driver_app')
+        .limit(1);
+      if ((driverHist?.length ?? 0) > 0) {
+        return res.status(400).json({
+          error: 'dispatcher_override_required',
+          detail: 'This event has driver-app history. Use the override flow with dispatcher_override_driver: true.',
+        });
+      }
+    }
+
     const updates = {};
     for (const f of EDITABLE) {
       if (req.body[f] !== undefined) updates[f] = req.body[f];

--- a/pages/api/tenant/loads/[id]/tracking.js
+++ b/pages/api/tenant/loads/[id]/tracking.js
@@ -82,19 +82,67 @@ export default async function handler(req, res) {
     } catch {}
   }
 
-  // Get routing events for the sidebar
+  // Get routing events for the sidebar (extended with ETA + event_status columns)
   const { data: routingEvents } = await svc
     .from('order_routing_events')
-    .select('id, sequence, event_type, location_name, city, state, arrived_at, departed_at, move_id')
+    .select(`
+      id, sequence, event_type, location_name, city, state, arrived_at, departed_at, move_id,
+      event_status,
+      eta_arrival_at, eta_updated_at, eta_distance_remaining_miles
+    `)
     .eq('order_id', id)
     .order('sequence', { ascending: true });
 
-  // Get moves for grouping
+  // Get moves for grouping (extended with tracking session columns + driver join)
   const { data: movesData } = await svc
     .from('order_container_moves')
-    .select('id, sequence, status, started_at, completed_at')
+    .select(`
+      id, sequence, status, started_at, completed_at,
+      tracking_status, session_started_at, session_ended_at, last_ping_at,
+      ping_count, eta_recompute_count,
+      driver:drivers(id, name, location_tracking_enabled, tracking_consented_at, tracking_revoked_at, tracking_consent_version)
+    `)
     .eq('order_id', id)
     .order('sequence', { ascending: true });
+
+  // Pings — latest 1000 per load (filtered by move_ids in this load)
+  const moveIds = (movesData || []).map((m) => m.id);
+  let pings = [];
+  if (moveIds.length > 0) {
+    const { data } = await svc
+      .from('driver_location_pings')
+      .select('id, move_id, latitude, longitude, accuracy_meters, speed_mph, heading, recorded_at, received_at')
+      .eq('tenant_id', ctx.tenantId)
+      .in('move_id', moveIds)
+      .order('recorded_at', { ascending: false })
+      .limit(1000);
+    pings = data || [];
+  }
+
+  // Event-status transitions for the activity log
+  let events_history = [];
+  const eventIds = (routingEvents || []).map((e) => e.id);
+  if (eventIds.length > 0) {
+    const { data } = await svc
+      .from('order_routing_event_status_history')
+      .select('id, event_id, from_status, to_status, transitioned_at, actor_id, actor_type, actor_context, note')
+      .eq('tenant_id', ctx.tenantId)
+      .in('event_id', eventIds)
+      .order('transitioned_at', { ascending: false });
+    events_history = data || [];
+  }
+
+  // Move-tracking session transitions for the activity log
+  let moves_history = [];
+  if (moveIds.length > 0) {
+    const { data } = await svc
+      .from('move_tracking_session_history')
+      .select('id, move_id, from_status, to_status, transitioned_at, actor_id, actor_type, actor_context, note')
+      .eq('tenant_id', ctx.tenantId)
+      .in('move_id', moveIds)
+      .order('transitioned_at', { ascending: false });
+    moves_history = data || [];
+  }
 
   return res.status(200).json({
     last_ping: lastPing,
@@ -109,5 +157,8 @@ export default async function handler(req, res) {
       delivery: load.delivery_org || null,
       return: load.return_org || null,
     },
+    pings,
+    events_history,
+    moves_history,
   });
 }

--- a/pages/driver/_components/ConsentScreen.js
+++ b/pages/driver/_components/ConsentScreen.js
@@ -1,0 +1,30 @@
+import { CONSENT_TITLE, CONSENT_BODY } from '../../../lib/driver-consent/text.js';
+import { CURRENT_CONSENT_VERSION } from '../../../lib/driver-consent/version.js';
+import { driverFetch } from '../../../lib/driver-app/auth.js';
+
+export default function ConsentScreen({ onAccept, onDecline }) {
+  async function handleAccept() {
+    const res = await driverFetch('/api/driver/me/consent', {
+      method: 'POST',
+      body: JSON.stringify({ version: CURRENT_CONSENT_VERSION }),
+    });
+    if (res.ok) onAccept?.();
+    else alert('Could not save consent — try again');
+  }
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 border border-gray-200 dark:border-gray-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{CONSENT_TITLE}</h2>
+        <pre className="mt-3 text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-sans">{CONSENT_BODY}</pre>
+        <div className="mt-4 flex gap-2 justify-end">
+          <button onClick={onDecline} className="px-3 py-1.5 text-sm rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300">
+            Decline
+          </button>
+          <button onClick={handleAccept} className="px-3 py-1.5 text-sm rounded bg-blue-600 hover:bg-blue-700 text-white">
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/driver/change-password.js
+++ b/pages/driver/change-password.js
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function DriverChangePassword() {
+  const router = useRouter();
+  const [oldPwd, setOld] = useState('');
+  const [newPwd, setNew] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    if (newPwd !== confirm) {
+      setError('New passwords do not match');
+      return;
+    }
+    if (newPwd.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const token = localStorage.getItem('dd_driver_token');
+      const res = await fetch('/api/driver/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ old_password: oldPwd, new_password: newPwd }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.detail || data.error || 'Password change failed');
+        return;
+      }
+      // password change invalidates current token; clear and re-login
+      localStorage.removeItem('dd_driver_token');
+      router.push('/driver/login');
+    } catch (err) {
+      setError('Network error — try again');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4 border border-gray-200 dark:border-gray-700"
+      >
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Set Your Password</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Your dispatcher gave you a temporary password. Choose a new one to continue.
+        </p>
+        {[
+          { label: 'Current password', val: oldPwd, set: setOld, autoComplete: 'current-password' },
+          { label: 'New password', val: newPwd, set: setNew, autoComplete: 'new-password' },
+          { label: 'Confirm new password', val: confirm, set: setConfirm, autoComplete: 'new-password' },
+        ].map((f) => (
+          <div key={f.label}>
+            <label className="block text-sm text-gray-700 dark:text-gray-300">{f.label}</label>
+            <input
+              type="password" value={f.val} onChange={(e) => f.set(e.target.value)}
+              autoComplete={f.autoComplete} required
+              className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+          </div>
+        ))}
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+        <button
+          type="submit" disabled={submitting}
+          className="w-full rounded bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white py-2 font-medium"
+        >
+          {submitting ? 'Saving…' : 'Save Password'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/pages/driver/index.js
+++ b/pages/driver/index.js
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { driverFetch, getToken, getDriverId } from '../../lib/driver-app/auth.js';
+
+export default function DriverHome() {
+  const router = useRouter();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push('/driver/login');
+      return;
+    }
+    (async () => {
+      try {
+        const [meRes, movesRes] = await Promise.all([
+          driverFetch('/api/driver/me'),
+          driverFetch('/api/driver/moves/today'),
+        ]);
+        if (meRes.status === 401 || movesRes.status === 401) return;  // redirected by interceptor
+        const me = await meRes.json();
+        const moves = await movesRes.json();
+        setData({ me, moves: moves.moves || [] });
+      } catch (e) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  if (loading) return <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 text-gray-600 dark:text-gray-400">Loading…</div>;
+  if (error) return <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 text-red-600 dark:text-red-400">Error: {error}</div>;
+  if (!data) return null;
+
+  const { me, moves } = data;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Hi, {me.driver.name || 'Driver'}</h1>
+          <p className="text-xs text-gray-500 dark:text-gray-400">Today's moves</p>
+        </div>
+        <button
+          onClick={() => router.push('/driver/settings')}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Settings
+        </button>
+      </header>
+
+      {!me.tracking.eligible && (
+        <div className="bg-amber-50 dark:bg-amber-950 border-b border-amber-200 dark:border-amber-900 p-3 text-sm text-amber-800 dark:text-amber-200">
+          {me.tracking.tenant_feature_enabled
+            ? me.tracking.driver_toggle_enabled
+              ? 'Location tracking requires your consent. Tap a move to review.'
+              : 'Your dispatcher has disabled location tracking for your account.'
+            : 'Your company has not enabled location tracking.'}
+        </div>
+      )}
+
+      <main className="p-4 space-y-2">
+        {moves.length === 0 && (
+          <div className="text-sm text-gray-500 dark:text-gray-400 p-4 text-center">No moves assigned for today.</div>
+        )}
+        {moves.map((m) => (
+          <button
+            key={m.id}
+            onClick={() => router.push(`/driver/move/${m.id}`)}
+            className="block w-full text-left bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-600"
+          >
+            <div className="flex items-center justify-between">
+              <div className="font-medium text-gray-900 dark:text-gray-100">
+                {m.order?.order_number || `Move ${m.id.slice(0, 8)}`}
+              </div>
+              <span className="text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 capitalize">
+                {m.tracking_status === 'idle' ? 'Not started' : m.tracking_status.replace('_', ' ')}
+              </span>
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {[m.order?.container_number, m.order?.container_size].filter(Boolean).join(' · ') || '—'}
+            </div>
+            <div className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+              {(m.events || []).map((e) => e.location_name || '?').join(' → ')}
+            </div>
+          </button>
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/pages/driver/login.js
+++ b/pages/driver/login.js
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function DriverLogin() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/driver/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.detail || data.error || 'Login failed');
+        return;
+      }
+      localStorage.setItem('dd_driver_token', data.token);
+      localStorage.setItem('dd_driver_id', data.driver.id);
+      localStorage.setItem('dd_driver_name', data.driver.name || '');
+      if (data.driver.must_change_password) {
+        router.push('/driver/change-password');
+      } else {
+        router.push('/driver');
+      }
+    } catch (err) {
+      setError('Network error — try again');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4 border border-gray-200 dark:border-gray-700"
+      >
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Driver Sign In</h1>
+        <div>
+          <label className="block text-sm text-gray-700 dark:text-gray-300">Username</label>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            autoComplete="username" required
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 dark:text-gray-300">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            autoComplete="current-password" required
+          />
+        </div>
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+        <button
+          type="submit" disabled={submitting}
+          className="w-full rounded bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white py-2 font-medium"
+        >
+          {submitting ? 'Signing in…' : 'Sign In'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/pages/driver/move/[id].js
+++ b/pages/driver/move/[id].js
@@ -1,0 +1,270 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import { driverFetch, getToken } from '../../../lib/driver-app/auth.js';
+import { startScheduler } from '../../../lib/driver-app/ping-scheduler.js';
+import { recordAction, getRemainingMs, fmtRemaining } from '../../../lib/driver-app/undo-timer.js';
+import { isConsentValid } from '../../../lib/driver-consent/version.js';
+import ConsentScreen from '../_components/ConsentScreen.js';
+
+function getCurrentPositionAsync() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) return reject(new Error('geolocation unavailable'));
+    navigator.geolocation.getCurrentPosition(
+      (p) => resolve(p),
+      (err) => reject(err),
+      { enableHighAccuracy: true, timeout: 30000, maximumAge: 0 },
+    );
+  });
+}
+
+function pingFromPosition(p) {
+  return {
+    latitude: p.coords.latitude,
+    longitude: p.coords.longitude,
+    accuracy_meters: p.coords.accuracy ?? null,
+    speed_mph: p.coords.speed != null ? (p.coords.speed * 3600) / 1609.344 : null,
+    heading: p.coords.heading ?? null,
+    battery_pct: null,
+    recorded_at: new Date(p.timestamp).toISOString(),
+  };
+}
+
+export default function DriverMoveDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [me, setMe] = useState(null);
+  const [move, setMove] = useState(null);
+  const [error, setError] = useState(null);
+  const [showConsent, setShowConsent] = useState(false);
+  const [actionInFlight, setActionInFlight] = useState(false);
+  const [undoMs, setUndoMs] = useState(getRemainingMs());
+  const schedulerRef = useRef(null);
+
+  // Load /me + /move
+  async function reload() {
+    const [meRes, mvRes] = await Promise.all([
+      driverFetch('/api/driver/me'),
+      driverFetch(`/api/driver/moves/${id}`),
+    ]);
+    if (mvRes.status === 404) { setError('Move not found'); return; }
+    if (mvRes.status === 403) { setError('You are not assigned to this move.'); return; }
+    const meJson = await meRes.json();
+    const mvJson = await mvRes.json();
+    setMe(meJson);
+    setMove(mvJson.move);
+    if (!isConsentValid(meJson.driver) && meJson.tracking.tenant_feature_enabled && meJson.tracking.driver_toggle_enabled) {
+      setShowConsent(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!getToken()) { router.push('/driver/login'); return; }
+    if (!id) return;
+    reload();
+  }, [id, router]);
+
+  // Manage scheduler lifecycle based on tracking_status
+  useEffect(() => {
+    if (!move) return;
+    const status = move.tracking_status;
+    const shouldRun = status === 'in_transit' || status === 'on_site' || status === 'paused';
+    if (shouldRun && !schedulerRef.current) {
+      schedulerRef.current = startScheduler({
+        moveId: id,
+        getMoveStatus: () => move?.tracking_status,
+        onSendError: (e) => console.warn('ping send error:', e),
+      });
+    }
+    if (!shouldRun && schedulerRef.current) {
+      schedulerRef.current.stop();
+      schedulerRef.current = null;
+    }
+    return () => {
+      if (schedulerRef.current) {
+        schedulerRef.current.stop();
+        schedulerRef.current = null;
+      }
+    };
+  }, [id, move?.tracking_status]);
+
+  // Undo countdown ticker
+  useEffect(() => {
+    const t = setInterval(() => setUndoMs(getRemainingMs()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  // wakeLock — best-effort
+  useEffect(() => {
+    let lock = null;
+    (async () => {
+      try { lock = await navigator.wakeLock?.request('screen'); } catch {}
+    })();
+    return () => { try { lock?.release?.(); } catch {} };
+  }, []);
+
+  if (error) return <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 text-red-600 dark:text-red-400">{error}</div>;
+  if (!move || !me) return <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 text-gray-600 dark:text-gray-400">Loading…</div>;
+
+  const events = move.events || [];
+  const nextPending = events.find((e) => e.event_status === 'pending');
+  const currentArrived = events.find((e) => e.event_status === 'arrived');
+
+  async function fireAction(actionType, extra = {}) {
+    if (actionInFlight) return;
+    setActionInFlight(true);
+    try {
+      const pos = await getCurrentPositionAsync();
+      const gpsPing = pingFromPosition(pos);
+      const url = `/api/driver/moves/${id}/${actionType}`;
+      const body = { gpsPing, ...extra };
+      const res = await driverFetch(url, { method: 'POST', body: JSON.stringify(body) });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 409 && data.error === 'gps_drift_warning') {
+        const ok = window.confirm(
+          `You appear to be ${(data.gps_distance_m / 1609).toFixed(1)} mi from this location. Confirm anyway?`,
+        );
+        if (ok) {
+          await fireAction(actionType, { ...extra, override_distance_warning: true });
+        }
+        return;
+      }
+      if (!res.ok) {
+        alert(`Action failed: ${data.error || res.status}`);
+        return;
+      }
+      recordAction();
+      setUndoMs(getRemainingMs());
+      await reload();
+    } catch (err) {
+      alert(`Could not get GPS: ${err.message}`);
+    } finally {
+      setActionInFlight(false);
+    }
+  }
+
+  async function fireUndo() {
+    if (actionInFlight) return;
+    setActionInFlight(true);
+    try {
+      const res = await driverFetch(`/api/driver/moves/${id}/undo`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        alert(`Undo failed: ${data.error || res.status}`);
+        return;
+      }
+      sessionStorage.removeItem('dd_driver_last_action_at');
+      setUndoMs(0);
+      await reload();
+    } finally {
+      setActionInFlight(false);
+    }
+  }
+
+  function PrimaryButton() {
+    if (move.tracking_status === 'idle') {
+      return (
+        <button
+          onClick={() => fireAction('start')}
+          disabled={actionInFlight}
+          className="w-full py-4 rounded-lg bg-green-600 hover:bg-green-700 text-white text-lg font-semibold disabled:opacity-50"
+        >
+          Start move
+        </button>
+      );
+    }
+    if (move.tracking_status === 'in_transit' && nextPending) {
+      return (
+        <button
+          onClick={() => fireAction('arrive', { targetEventId: nextPending.id })}
+          disabled={actionInFlight}
+          className="w-full py-4 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-lg font-semibold disabled:opacity-50"
+        >
+          I'm here at {nextPending.location_name || 'destination'}
+        </button>
+      );
+    }
+    if (move.tracking_status === 'on_site' && currentArrived) {
+      return (
+        <button
+          onClick={() => fireAction('depart', { targetEventId: currentArrived.id })}
+          disabled={actionInFlight}
+          className="w-full py-4 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-lg font-semibold disabled:opacity-50"
+        >
+          Leaving {currentArrived.location_name || 'location'}
+        </button>
+      );
+    }
+    if (move.tracking_status === 'paused') {
+      return (
+        <button
+          disabled
+          className="w-full py-4 rounded-lg bg-gray-300 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-lg font-semibold"
+        >
+          Resume tracking (auto on next ping)
+        </button>
+      );
+    }
+    if (move.tracking_status === 'completed') {
+      return (
+        <div className="text-center text-gray-700 dark:text-gray-300 py-4">
+          ✓ Move complete — well done.
+        </div>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 pb-32">
+      {showConsent && <ConsentScreen onAccept={() => { setShowConsent(false); reload(); }} onDecline={() => router.push('/driver')} />}
+
+      <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4">
+        <button onClick={() => router.push('/driver')} className="text-sm text-blue-600 dark:text-blue-400">← Back</button>
+        <h1 className="mt-1 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          {move.order?.order_number || `Move ${move.id.slice(0, 8)}`}
+        </h1>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {[move.order?.container_number, move.order?.container_size].filter(Boolean).join(' · ') || '—'}
+        </p>
+      </header>
+
+      <ol className="p-4 space-y-3">
+        {events.map((e, idx) => {
+          const status = e.event_status;
+          const tone =
+            status === 'departed' ? 'bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-900' :
+            status === 'arrived' ? 'bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-900' :
+            status === 'skipped' ? 'bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 opacity-60' :
+            'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700';
+          return (
+            <li key={e.id} className={`rounded-lg border p-3 ${tone}`}>
+              <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{idx + 1}. {e.event_type}</div>
+              <div className="text-xs text-gray-700 dark:text-gray-300">{e.location_name || 'No location'}</div>
+              <div className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+                {e.scheduled_at && <>Apt {new Date(e.scheduled_at).toLocaleString()}</>}
+                {e.arrived_at && <> · Arrived {new Date(e.arrived_at).toLocaleTimeString()}</>}
+                {e.departed_at && <> · Departed {new Date(e.departed_at).toLocaleTimeString()}</>}
+                {!e.arrived_at && !e.departed_at && e.eta_arrival_at && (
+                  <> · ETA {new Date(e.eta_arrival_at).toLocaleTimeString()}</>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="fixed bottom-0 inset-x-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 p-4 space-y-2">
+        <PrimaryButton />
+        {undoMs > 0 && (
+          <button
+            onClick={fireUndo}
+            disabled={actionInFlight}
+            className="w-full text-sm text-amber-700 dark:text-amber-400 hover:underline disabled:opacity-50"
+          >
+            Undo last action ({fmtRemaining(undoMs)} remaining)
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pages/driver/settings.js
+++ b/pages/driver/settings.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { driverFetch, clearSession, getToken } from '../../lib/driver-app/auth.js';
+
+export default function DriverSettings() {
+  const router = useRouter();
+  const [me, setMe] = useState(null);
+
+  useEffect(() => {
+    if (!getToken()) { router.push('/driver/login'); return; }
+    (async () => {
+      const res = await driverFetch('/api/driver/me');
+      if (res.ok) setMe(await res.json());
+    })();
+  }, [router]);
+
+  async function revokeConsent() {
+    if (!confirm('Revoke location tracking? Your dispatcher will need manual updates from you.')) return;
+    const res = await driverFetch('/api/driver/me/revoke-consent', { method: 'POST' });
+    if (res.ok) {
+      const refreshed = await driverFetch('/api/driver/me');
+      setMe(await refreshed.json());
+    }
+  }
+
+  function logout() {
+    clearSession();
+    router.push('/driver/login');
+  }
+
+  if (!me) return <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 text-gray-600 dark:text-gray-400">Loading…</div>;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-4 flex items-center justify-between">
+        <button onClick={() => router.push('/driver')} className="text-sm text-blue-600 dark:text-blue-400">← Back</button>
+        <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Settings</h1>
+        <span />
+      </header>
+
+      <main className="p-4 space-y-3">
+        <section className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Account</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{me.driver.name} · @{me.driver.username}</p>
+          <button onClick={() => router.push('/driver/change-password')} className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline">
+            Change password
+          </button>
+        </section>
+
+        <section className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Location tracking</h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {me.consent.valid ? 'Enabled — your location is shared while you work moves.' : 'Not active.'}
+          </p>
+          {me.consent.valid && (
+            <button onClick={revokeConsent} className="mt-2 text-sm text-red-600 dark:text-red-400 hover:underline">
+              Revoke tracking consent
+            </button>
+          )}
+        </section>
+
+        <button onClick={logout} className="w-full bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700 text-red-600 dark:text-red-400">
+          Sign out
+        </button>
+      </main>
+    </div>
+  );
+}

--- a/pages/settings/drivers.js
+++ b/pages/settings/drivers.js
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { Truck } from 'lucide-react';
+import SettingsLayout from '../../components/settings/SettingsLayout';
+import SettingsTabs from '../../components/settings/SettingsTabs';
+import { PageHeader } from '../../components/ui/ModuleHeader';
+
+export default function DriverSettingsPage() {
+  return (
+    <div className="space-y-[var(--space-section)]">
+      <PageHeader
+        variant="plain"
+        title={<><Truck className="w-6 h-6 text-blue-600 inline -mt-0.5 mr-2" />Drivers</>}
+        description="Tenant-wide driver settings."
+        className="mb-[var(--space-section)]"
+      />
+
+      <SettingsTabs />
+
+      <div className="mt-6">
+        <MoveTrackingCard />
+      </div>
+    </div>
+  );
+}
+
+function MoveTrackingCard() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/tenant/feature-flags/move-tracking');
+      if (res.ok) {
+        const data = await res.json();
+        setEnabled(!!data.enabled);
+      } else {
+        setError(`HTTP ${res.status}`);
+      }
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggle() {
+    const next = !enabled;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/tenant/feature-flags/move-tracking', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (res.ok) {
+        setEnabled(next);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.detail || data.error || `HTTP ${res.status}`);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-body font-semibold text-strong">Move Tracking</h3>
+        <button
+          onClick={toggle}
+          disabled={loading || submitting}
+          className={`px-3 py-1.5 text-sm rounded-lg font-medium transition-colors ${
+            enabled
+              ? 'bg-blue-600 hover:bg-blue-700 text-white'
+              : 'border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-800'
+          } disabled:opacity-50`}
+        >
+          {loading ? '…' : submitting ? 'Saving…' : enabled ? 'On' : 'Off'}
+        </button>
+      </div>
+      <p className="mt-2 text-helper text-muted">
+        Drivers can report arrivals and departures from their mobile app, and dispatchers see live
+        ETAs + breadcrumb history. Once enabled, all drivers default to tracked. Disable individual
+        drivers in their profile.
+      </p>
+      {error && <p className="mt-2 text-helper text-red-600 dark:text-red-400">Error: {error}</p>}
+    </div>
+  );
+}
+
+DriverSettingsPage.getLayout = (page) => (
+  <SettingsLayout title="Drivers">{page}</SettingsLayout>
+);

--- a/supabase/migrations/102_driver_move_tracking.sql
+++ b/supabase/migrations/102_driver_move_tracking.sql
@@ -1,0 +1,121 @@
+-- ============================================================
+-- Migration 102: Driver Move-Tracking Foundation
+-- ============================================================
+-- Builds on existing migration 036 driver-tracking scaffolding
+-- (driver_location_pings, geofence_events, drive_segments, plus
+-- drivers.last_latitude/longitude/last_location_at/etc.). Reuses
+-- where the shape matches; adds only what's net-new for FU-085.
+--
+-- Net-new additions:
+--   - driver_location_pings.move_id + .battery_pct (extend existing table)
+--   - order_container_moves: tracking_status state machine + session +
+--     last_ping_at + ping_count + eta_recompute_count
+--   - order_routing_events: ETA cache columns
+--   - drivers: 8 auth + consent columns
+--   - move_tracking_session_history audit table
+--   - driver_auth_attempts rate-limit table
+--   - move_tracking feature flag
+--
+-- Re-used (no new schema): driver_location_pings (table from 036),
+-- drivers.last_latitude/last_longitude/last_location_at/last_speed_mph/
+-- last_heading/last_location_source (columns from 036), geofence_events
+-- (table from 036, used by Phase 2).
+--
+-- Spec: docs/superpowers/specs/2026-04-24-driver-move-tracking-design.md
+-- FU-085. PR 1 of 7.
+-- ============================================================
+
+BEGIN;
+
+-- 1. Extend driver_location_pings (from migration 036) with move scoping +
+--    battery telemetry. The existing table has the right shape:
+--      - driver_id (NOT NULL) + order_id (nullable)
+--      - latitude/longitude NUMERIC(10,7) with valid_latitude/longitude CHECKs
+--      - source CHECK ('eld','mobile_app','manual')
+--      - heading NUMERIC(5,1), speed_mph NUMERIC(5,1), accuracy_meters NUMERIC(7,1)
+--      - eld_provider, eld_device_id (nullable; populated only for eld source)
+--      - recorded_at + received_at
+--      - RLS policies (pings_select, pings_insert)
+--    We add per-move scoping for breadcrumb fetch + battery for the mobile
+--    app's ping payload.
+ALTER TABLE driver_location_pings
+  ADD COLUMN IF NOT EXISTS move_id UUID REFERENCES order_container_moves(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS battery_pct INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_driver_location_pings_move_recorded
+  ON driver_location_pings(move_id, recorded_at DESC) WHERE move_id IS NOT NULL;
+
+-- 2. Tracking session state on order_container_moves.
+--    NOT adding current_lat/current_lng — drivers.last_latitude/last_longitude
+--    (from migration 036) already serves "where is the driver now". A driver
+--    works one in_transit/on_site move at a time, so per-driver denorm is
+--    sufficient. last_ping_at IS added here for staleness detection without
+--    a join (the stale-ping cron filters in_transit moves where last_ping_at
+--    < now() - 10min).
+ALTER TABLE order_container_moves
+  ADD COLUMN IF NOT EXISTS tracking_status TEXT NOT NULL DEFAULT 'idle'
+    CHECK (tracking_status IN ('idle','in_transit','on_site','paused','completed')),
+  ADD COLUMN IF NOT EXISTS session_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS session_ended_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_ping_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS ping_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS eta_recompute_count INTEGER NOT NULL DEFAULT 0;
+
+-- 3. ETA cache on order_routing_events
+ALTER TABLE order_routing_events
+  ADD COLUMN IF NOT EXISTS eta_arrival_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS eta_updated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS eta_distance_remaining_miles NUMERIC(7,2);
+
+-- 4. Driver auth + consent on drivers (no overlap with 036's location columns)
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS password_hash TEXT,
+  ADD COLUMN IF NOT EXISTS password_set_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS password_must_change BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS session_min_iat TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS location_tracking_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS tracking_consented_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS tracking_consent_version INTEGER,
+  ADD COLUMN IF NOT EXISTS tracking_revoked_at TIMESTAMPTZ;
+
+-- 5. Move-tracking session history (audit, mirrors B.1e pattern)
+CREATE TABLE IF NOT EXISTS move_tracking_session_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  move_id UUID NOT NULL REFERENCES order_container_moves(id) ON DELETE CASCADE,
+  from_status TEXT,
+  to_status TEXT NOT NULL,
+  transitioned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  actor_id UUID,
+  actor_type TEXT NOT NULL CHECK (actor_type IN ('human','system','agent')),
+  actor_context JSONB,
+  note TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tracking_session_history_move
+  ON move_tracking_session_history(move_id, transitioned_at DESC);
+
+-- 6. Driver login attempts (rate-limit by username)
+CREATE TABLE IF NOT EXISTS driver_auth_attempts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID,
+  username TEXT NOT NULL,
+  ip_address INET,
+  succeeded BOOLEAN NOT NULL,
+  attempted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_driver_auth_attempts_username_recent
+  ON driver_auth_attempts(username, attempted_at DESC);
+
+-- 7. Feature flag row.
+--    NOTE: feature_flags table uses is_active (NOT default_enabled).
+--    is_active=false registers globally-disabled; per-tenant
+--    tenant_feature_flags rows opt individual tenants in.
+INSERT INTO feature_flags (name, description, is_active)
+VALUES ('move_tracking', 'Driver mobile move tracking with live ETA + breadcrumbs', false)
+ON CONFLICT (name) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/dispatcher-tracking-display.test.mjs
+++ b/tests/dispatcher-tracking-display.test.mjs
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  fmtRelativeETA,
+  fmtAbsoluteETA,
+  fmtOnSiteDuration,
+  freshnessColor,
+} from '../lib/dispatcher/tracking-display.js';
+
+test('fmtRelativeETA — under 60 minutes', () => {
+  const future = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+  assert.match(fmtRelativeETA(future), /^30m$/);
+});
+
+test('fmtRelativeETA — over 60 minutes', () => {
+  const future = new Date(Date.now() + (2 * 60 + 14) * 60 * 1000).toISOString();
+  assert.match(fmtRelativeETA(future), /^2h 14m$/);
+});
+
+test('fmtRelativeETA — past time → "now"', () => {
+  const past = new Date(Date.now() - 60 * 1000).toISOString();
+  assert.equal(fmtRelativeETA(past), 'now');
+});
+
+test('fmtAbsoluteETA returns HH:MM in 24h format', () => {
+  const eta = new Date('2026-04-24T14:32:00Z').toISOString();
+  // We render in local time; assert format only.
+  assert.match(fmtAbsoluteETA(eta), /^\d{2}:\d{2}$/);
+});
+
+test('fmtOnSiteDuration mm:ss for <1h, h:mm:ss for >1h', () => {
+  const t45m = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+  assert.match(fmtOnSiteDuration(t45m), /^\d{1,2}:\d{2}$/);   // 45:00 (within hour)
+
+  const t75m = new Date(Date.now() - 75 * 60 * 1000).toISOString();
+  assert.match(fmtOnSiteDuration(t75m), /^1:\d{2}:\d{2}$/);
+});
+
+test('freshnessColor green/amber/red thresholds', () => {
+  const now = Date.now();
+  assert.equal(freshnessColor(new Date(now - 30 * 1000).toISOString()), 'green');
+  assert.equal(freshnessColor(new Date(now - 5 * 60 * 1000).toISOString()), 'amber');
+  assert.equal(freshnessColor(new Date(now - 15 * 60 * 1000).toISOString()), 'red');
+  assert.equal(freshnessColor(null), 'red');
+});

--- a/tests/driver-action.test.mjs
+++ b/tests/driver-action.test.mjs
@@ -1,0 +1,188 @@
+// tests/driver-action.test.mjs
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { applyDriverAction } from '../lib/routing/driver-action.js';
+
+function makeMockClient(state) {
+  const calls = { inserts: [], updates: [], selects: [] };
+  function chain(table) {
+    const c = {
+      _table: table, _filters: {}, _payload: null,
+      select() { return c; },
+      insert(p) {
+        calls.inserts.push({ table, payload: p });
+        // For pings: return inserted row with synthetic id
+        if (table === 'driver_location_pings') {
+          return {
+            select: () => ({
+              single: () => Promise.resolve({ data: { ...p, id: 'ping-id-1' }, error: null }),
+            }),
+          };
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+      update(p) {
+        c._payload = p;
+        calls.updates.push({ table, payload: p });
+        return c;
+      },
+      eq(col, val) { c._filters[col] = val; return c; },
+      maybeSingle() {
+        calls.selects.push({ table, filters: { ...c._filters } });
+        if (table === 'order_container_moves') {
+          return Promise.resolve({ data: state.move, error: null });
+        }
+        if (table === 'order_routing_events') {
+          if (c._filters.id) {
+            return Promise.resolve({ data: state.events.find((e) => e.id === c._filters.id) ?? null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+      single() {
+        if (c._payload != null) {
+          return Promise.resolve({ data: { ...c._payload, id: c._filters.id ?? 'mock' }, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+    };
+    return c;
+  }
+  return { from: (t) => chain(t), __calls: calls };
+}
+
+test('applyDriverAction(start) inserts ping into driver_location_pings + flips tracking_status idle→in_transit', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'idle', ping_count: 0 },
+    events: [],
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+    driverId: 'd1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+  });
+  const pingInsert = svc.__calls.inserts.find((i) => i.table === 'driver_location_pings');
+  assert.ok(pingInsert, 'expected ping insert into driver_location_pings');
+  assert.equal(pingInsert.payload.move_id, 'm1');
+  assert.equal(pingInsert.payload.driver_id, 'd1');
+  assert.equal(pingInsert.payload.source, 'mobile_app', 'driver-app pings always use mobile_app source');
+  assert.equal(pingInsert.payload.latitude, 37.1);
+  assert.equal(pingInsert.payload.longitude, -122.5);
+
+  const trackingUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.tracking_status === 'in_transit',
+  );
+  assert.ok(trackingUpdate, 'expected tracking_status update to in_transit');
+});
+
+test('applyDriverAction(start) updates drivers.last_* denorm columns', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'idle', ping_count: 0 },
+    events: [],
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+    driverId: 'd1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z', speed_mph: 35.5, heading: 180 },
+  });
+  const driverDenormUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'drivers' && u.payload.last_latitude === 37.1,
+  );
+  assert.ok(driverDenormUpdate, 'expected drivers.last_* denorm update');
+  assert.equal(driverDenormUpdate.payload.last_longitude, -122.5);
+  assert.equal(driverDenormUpdate.payload.last_location_source, 'mobile_app');
+  assert.ok(driverDenormUpdate.payload.last_location_at);
+});
+
+test('applyDriverAction(start) updates order_container_moves.last_ping_at + ping_count (NOT current_lat/lng)', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'idle', ping_count: 5 },
+    events: [],
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+    driverId: 'd1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+  });
+  // Find the move-counter update (the one with ping_count, NOT the tracking_status-only update)
+  const moveCounterUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.ping_count != null,
+  );
+  assert.ok(moveCounterUpdate, 'expected counter update on move row');
+  assert.equal(moveCounterUpdate.payload.ping_count, 6, 'incremented from 5');
+  assert.equal(moveCounterUpdate.payload.last_ping_at, '2026-04-24T12:00:00Z');
+  // CRITICAL: must NOT write current_lat/lng (those columns don't exist)
+  assert.equal(moveCounterUpdate.payload.current_lat, undefined, 'must NOT write current_lat');
+  assert.equal(moveCounterUpdate.payload.current_lng, undefined, 'must NOT write current_lng');
+});
+
+test('applyDriverAction(arrive) flips event pending→arrived AND tracking in_transit→on_site', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'in_transit', ping_count: 5 },
+    events: [{
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'pull', event_status: 'pending',
+      arrived_at: null, departed_at: null,
+    }],
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'arrive',
+    driverId: 'd1',
+    targetEventId: 'e1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:30:00Z' },
+  });
+  const eventUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_routing_events' && u.payload.event_status === 'arrived',
+  );
+  assert.ok(eventUpdate, 'expected event_status update to arrived');
+  const trackingUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.tracking_status === 'on_site',
+  );
+  assert.ok(trackingUpdate, 'expected tracking_status update to on_site');
+});
+
+test('applyDriverAction rejects start when tracking_status is not idle', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'in_transit', ping_count: 5 },
+    events: [],
+  });
+  await assert.rejects(
+    applyDriverAction({
+      supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+      driverId: 'd1',
+      gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+    }),
+    /Invalid transition: in_transit -> in_transit/,
+  );
+});
+
+test('applyDriverAction rejects ping over 40-cap', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'in_transit', ping_count: 40 },
+    events: [],
+  });
+  await assert.rejects(
+    applyDriverAction({
+      supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+      driverId: 'd1',
+      gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+    }),
+    /ping_cap_reached/,
+  );
+});
+
+test('applyDriverAction rejects when driver does not own the move', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'OTHER_DRIVER', tracking_status: 'idle', ping_count: 0 },
+    events: [],
+  });
+  await assert.rejects(
+    applyDriverAction({
+      supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+      driverId: 'd1',
+      gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+    }),
+    /forbidden/,
+  );
+});

--- a/tests/driver-action.test.mjs
+++ b/tests/driver-action.test.mjs
@@ -7,7 +7,7 @@ function makeMockClient(state) {
   const calls = { inserts: [], updates: [], selects: [] };
   function chain(table) {
     const c = {
-      _table: table, _filters: {}, _payload: null,
+      _table: table, _filters: {}, _negFilters: [], _payload: null, _terminated: false,
       select() { return c; },
       insert(p) {
         calls.inserts.push({ table, payload: p });
@@ -27,6 +27,7 @@ function makeMockClient(state) {
         return c;
       },
       eq(col, val) { c._filters[col] = val; return c; },
+      neq(col, val) { c._negFilters.push([col, val]); return c; },
       maybeSingle() {
         calls.selects.push({ table, filters: { ...c._filters } });
         if (table === 'order_container_moves') {
@@ -45,6 +46,21 @@ function makeMockClient(state) {
           return Promise.resolve({ data: { ...c._payload, id: c._filters.id ?? 'mock' }, error: null });
         }
         return Promise.resolve({ data: null, error: null });
+      },
+      // Thenable: when a query is awaited directly (no .single/.maybeSingle
+      // terminator), resolve with the predefined array. Used by the depart
+      // path's laterEvents query.
+      then(onFulfilled, onRejected) {
+        calls.selects.push({ table, filters: { ...c._filters }, neq: [...c._negFilters] });
+        let data = null;
+        if (table === 'order_routing_events') {
+          // Caller is asking for "events on this move that aren't departed/skipped/me"
+          data = state.laterEvents ?? [];
+        } else if (c._payload != null) {
+          // An UPDATE without .select() — resolve to {data:null, error:null}
+          data = null;
+        }
+        return Promise.resolve({ data, error: null }).then(onFulfilled, onRejected);
       },
     };
     return c;
@@ -157,9 +173,9 @@ test('applyDriverAction rejects start when tracking_status is not idle', async (
   );
 });
 
-test('applyDriverAction rejects ping over 40-cap', async () => {
+test('applyDriverAction rejects ping over PING_CAP (500)', async () => {
   const svc = makeMockClient({
-    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'in_transit', ping_count: 40 },
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'in_transit', ping_count: 500 },
     events: [],
   });
   await assert.rejects(
@@ -170,6 +186,23 @@ test('applyDriverAction rejects ping over 40-cap', async () => {
     }),
     /ping_cap_reached/,
   );
+});
+
+test('applyDriverAction allows ping at 499 (just under cap)', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'idle', ping_count: 499 },
+    events: [],
+  });
+  // Should NOT throw
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+    driverId: 'd1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+  });
+  const counterUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.ping_count === 500,
+  );
+  assert.ok(counterUpdate, 'expected ping_count to land at exactly the cap');
 });
 
 test('applyDriverAction rejects when driver does not own the move', async () => {
@@ -185,4 +218,66 @@ test('applyDriverAction rejects when driver does not own the move', async () => 
     }),
     /forbidden/,
   );
+});
+
+test('applyDriverAction rejects when move has no driver assigned (move_unassigned)', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: null, tracking_status: 'idle', ping_count: 0 },
+    events: [],
+  });
+  await assert.rejects(
+    applyDriverAction({
+      supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'start',
+      driverId: 'd1',
+      gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:00:00Z' },
+    }),
+    /move_unassigned/,
+  );
+});
+
+test('applyDriverAction(depart) with remaining events flips tracking_status → in_transit', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'on_site', ping_count: 5 },
+    events: [{
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'pull', event_status: 'arrived',
+      arrived_at: '2026-04-24T12:00:00Z', departed_at: null,
+    }],
+    // The laterEvents query returns a non-empty array → in_transit
+    laterEvents: [{ id: 'e2', event_status: 'pending' }, { id: 'e3', event_status: 'pending' }],
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'depart',
+    driverId: 'd1', targetEventId: 'e1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T12:30:00Z' },
+  });
+  const eventUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_routing_events' && u.payload.event_status === 'departed',
+  );
+  assert.ok(eventUpdate, 'expected event_status update to departed');
+  const trackingUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.tracking_status === 'in_transit',
+  );
+  assert.ok(trackingUpdate, 'expected tracking_status update to in_transit (events remain)');
+});
+
+test('applyDriverAction(depart) with no remaining events flips tracking_status → completed', async () => {
+  const svc = makeMockClient({
+    move: { id: 'm1', tenant_id: 't1', driver_id: 'd1', tracking_status: 'on_site', ping_count: 5 },
+    events: [{
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'return', event_status: 'arrived',
+      arrived_at: '2026-04-24T12:00:00Z', departed_at: null,
+    }],
+    laterEvents: [],  // last event of the move
+  });
+  await applyDriverAction({
+    supabase: svc, tenantId: 't1', moveId: 'm1', actionType: 'depart',
+    driverId: 'd1', targetEventId: 'e1',
+    gpsPing: { latitude: 37.1, longitude: -122.5, recorded_at: '2026-04-24T13:00:00Z' },
+  });
+  const trackingUpdate = svc.__calls.updates.find(
+    (u) => u.table === 'order_container_moves' && u.payload.tracking_status === 'completed',
+  );
+  assert.ok(trackingUpdate, 'expected tracking_status update to completed (last event)');
 });

--- a/tests/driver-auth-middleware.test.mjs
+++ b/tests/driver-auth-middleware.test.mjs
@@ -1,0 +1,108 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { signDriverJWT } from '../lib/driver-auth/utils.js';
+import { requireDriver, __setServiceClientForTesting } from '../lib/driver-auth/middleware.js';
+
+const SECRET = 'test-secret';
+process.env.DRIVER_JWT_SECRET = SECRET;
+
+function makeRes() {
+  const r = { _status: null, _body: null };
+  r.status = (s) => { r._status = s; return r; };
+  r.json = (b) => { r._body = b; return r; };
+  return r;
+}
+
+function makeMockSvc(driverRow) {
+  return {
+    from: (table) => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            is: () => ({
+              maybeSingle: () => Promise.resolve({ data: driverRow, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+test('requireDriver returns 401 when Authorization header missing', async () => {
+  __setServiceClientForTesting(makeMockSvc(null));
+  const req = { headers: {} };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.equal(result, null);
+  assert.equal(res._status, 401);
+});
+
+test('requireDriver returns 401 on invalid JWT', async () => {
+  __setServiceClientForTesting(makeMockSvc(null));
+  const req = { headers: { authorization: 'Bearer not.a.jwt' } };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.equal(result, null);
+  assert.equal(res._status, 401);
+});
+
+test('requireDriver returns 401 when driver not found', async () => {
+  __setServiceClientForTesting(makeMockSvc(null));
+  const token = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, SECRET);
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.equal(result, null);
+  assert.equal(res._status, 401);
+});
+
+test('requireDriver returns 401 when JWT iat < session_min_iat', async () => {
+  // Sign a token with an iat in the past
+  const oldToken = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, SECRET);
+  const futureMinIat = new Date(Date.now() + 86400 * 1000).toISOString();
+  __setServiceClientForTesting(makeMockSvc({
+    id: 'd1', tenant_id: 't1', status: 'active',
+    session_min_iat: futureMinIat,
+    location_tracking_enabled: true,
+  }));
+  const req = { headers: { authorization: `Bearer ${oldToken}` } };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.equal(result, null);
+  assert.equal(res._status, 401);
+});
+
+test('requireDriver returns ctx on valid token + active driver', async () => {
+  __setServiceClientForTesting(makeMockSvc({
+    id: 'd1', tenant_id: 't1', name: 'Test Driver', username: 'tdriver',
+    status: 'active',
+    session_min_iat: '2020-01-01T00:00:00Z',
+    location_tracking_enabled: true,
+    password_must_change: false,
+    tracking_consented_at: null,
+    tracking_consent_version: null,
+    tracking_revoked_at: null,
+  }));
+  const token = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, SECRET);
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.ok(result, 'expected non-null ctx');
+  assert.equal(result.driverId, 'd1');
+  assert.equal(result.tenantId, 't1');
+  assert.equal(result.driver.status, 'active');
+});
+
+test('requireDriver returns 401 when driver status is not active', async () => {
+  __setServiceClientForTesting(makeMockSvc({
+    id: 'd1', tenant_id: 't1', status: 'inactive',
+    session_min_iat: '2020-01-01T00:00:00Z',
+  }));
+  const token = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, SECRET);
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = makeRes();
+  const result = await requireDriver(req, res);
+  assert.equal(result, null);
+  assert.equal(res._status, 401);
+});

--- a/tests/driver-auth-utils.test.mjs
+++ b/tests/driver-auth-utils.test.mjs
@@ -1,0 +1,51 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  hashPassword,
+  verifyPassword,
+  signDriverJWT,
+  verifyDriverJWT,
+  generateTempPassword,
+  TOKEN_TTL_DAYS,
+} from '../lib/driver-auth/utils.js';
+
+const TEST_SECRET = 'test-secret-do-not-use-in-prod';
+
+test('hashPassword + verifyPassword round-trip', async () => {
+  const hash = await hashPassword('correct-horse');
+  assert.ok(hash.startsWith('$2'));
+  assert.equal(await verifyPassword('correct-horse', hash), true);
+  assert.equal(await verifyPassword('battery-staple', hash), false);
+});
+
+test('signDriverJWT + verifyDriverJWT round-trip', async () => {
+  const token = signDriverJWT(
+    { driverId: 'd1', tenantId: 't1' },
+    TEST_SECRET,
+  );
+  assert.equal(typeof token, 'string');
+  const claims = verifyDriverJWT(token, TEST_SECRET);
+  assert.equal(claims.driverId, 'd1');
+  assert.equal(claims.tenantId, 't1');
+  assert.equal(typeof claims.iat, 'number');
+  assert.equal(typeof claims.exp, 'number');
+  assert.ok(claims.exp - claims.iat >= TOKEN_TTL_DAYS * 86400 - 1);
+});
+
+test('verifyDriverJWT rejects tampered token', async () => {
+  const token = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, TEST_SECRET);
+  const parts = token.split('.');
+  parts[2] = parts[2].slice(0, -2) + 'AA';
+  assert.throws(() => verifyDriverJWT(parts.join('.'), TEST_SECRET));
+});
+
+test('verifyDriverJWT rejects token signed with different secret', () => {
+  const token = signDriverJWT({ driverId: 'd1', tenantId: 't1' }, TEST_SECRET);
+  assert.throws(() => verifyDriverJWT(token, 'different-secret'));
+});
+
+test('generateTempPassword produces 8-char alphanumeric', () => {
+  const p = generateTempPassword();
+  assert.equal(p.length, 8);
+  assert.match(p, /^[A-Za-z0-9]+$/);
+});

--- a/tests/driver-consent-state.test.mjs
+++ b/tests/driver-consent-state.test.mjs
@@ -1,0 +1,42 @@
+// tests/driver-consent-state.test.mjs
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { isConsentValid, CURRENT_CONSENT_VERSION } from '../lib/driver-consent/version.js';
+
+test('isConsentValid: never asked → false', () => {
+  assert.equal(isConsentValid({
+    tracking_consented_at: null, tracking_revoked_at: null, tracking_consent_version: null,
+  }), false);
+});
+
+test('isConsentValid: accepted current version, not revoked → true', () => {
+  assert.equal(isConsentValid({
+    tracking_consented_at: '2026-04-24T12:00:00Z',
+    tracking_revoked_at: null,
+    tracking_consent_version: CURRENT_CONSENT_VERSION,
+  }), true);
+});
+
+test('isConsentValid: revoked after accepted → false', () => {
+  assert.equal(isConsentValid({
+    tracking_consented_at: '2026-04-24T12:00:00Z',
+    tracking_revoked_at: '2026-04-24T13:00:00Z',
+    tracking_consent_version: CURRENT_CONSENT_VERSION,
+  }), false);
+});
+
+test('isConsentValid: re-accepted after revoke → true (consented_at > revoked_at)', () => {
+  assert.equal(isConsentValid({
+    tracking_consented_at: '2026-04-24T14:00:00Z',
+    tracking_revoked_at: '2026-04-24T13:00:00Z',
+    tracking_consent_version: CURRENT_CONSENT_VERSION,
+  }), true);
+});
+
+test('isConsentValid: stale consent version → false', () => {
+  assert.equal(isConsentValid({
+    tracking_consented_at: '2026-04-24T12:00:00Z',
+    tracking_revoked_at: null,
+    tracking_consent_version: CURRENT_CONSENT_VERSION - 1,
+  }), false);
+});

--- a/tests/event-status-transition-fires-routing-triggers.test.mjs
+++ b/tests/event-status-transition-fires-routing-triggers.test.mjs
@@ -79,3 +79,27 @@ test('transitionEventStatus pending → skipped does NOT fire trigger (no timest
   });
   assert.equal(fireCalls.length, 0, 'skip does not fire triggers');
 });
+
+test('transitionEventStatus departed with forgotten arrival fires BOTH arrived + departed triggers', async () => {
+  // Edge case: event was somehow set to 'arrived' status without a timestamp
+  // (race, raw SQL bypass, or upstream bug). The departed transition auto-fills
+  // arrived_at, which means BOTH triggers should fire — same physical moment,
+  // two semantic events for the dispatcher's email pipeline.
+  fireCalls.length = 0;
+  const svc = makeMockClient({
+    event: {
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'deliver', event_status: 'arrived',
+      arrived_at: null, departed_at: null,
+    },
+  });
+  await transitionEventStatus({
+    supabase: svc, tenantId: 't1', eventId: 'e1', toStatus: 'departed',
+    actor: { type: 'human' },
+  });
+  assert.equal(fireCalls.length, 2, 'expected both arrived + departed triggers to fire');
+  assert.equal(fireCalls[0].timestampField, 'arrived_at', 'arrived fires first');
+  assert.equal(fireCalls[1].timestampField, 'departed_at', 'departed fires second');
+  assert.equal(fireCalls[0].eventType, 'deliver');
+  assert.equal(fireCalls[1].eventType, 'deliver');
+});

--- a/tests/event-status-transition-fires-routing-triggers.test.mjs
+++ b/tests/event-status-transition-fires-routing-triggers.test.mjs
@@ -1,0 +1,81 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+// Track calls to fireRoutingEventTriggers via a module mock.
+const fireCalls = [];
+
+// Need to import after we've set up a way to intercept the trigger fire.
+// Approach: monkey-patch module via a setter the helper exposes for tests.
+import { transitionEventStatus, __setFireRoutingEventTriggersForTesting } from '../lib/routing/event-status-transition.js';
+
+__setFireRoutingEventTriggersForTesting(async (svc, args) => {
+  fireCalls.push(args);
+});
+
+function makeMockClient({ event }) {
+  function chain(table) {
+    const c = {
+      _table: table, _payload: null,
+      select() { return c; },
+      update(p) { c._payload = p; return c; },
+      insert() { return Promise.resolve({ data: null, error: null }); },
+      eq() { return c; },
+      async maybeSingle() { return { data: event, error: null }; },
+      single() { return Promise.resolve({ data: { ...event, ...c._payload }, error: null }); },
+    };
+    return c;
+  }
+  return { from: chain };
+}
+
+test('transitionEventStatus pending → arrived fires arrived trigger', async () => {
+  fireCalls.length = 0;
+  const svc = makeMockClient({
+    event: {
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'pull', event_status: 'pending',
+      arrived_at: null, departed_at: null,
+    },
+  });
+  await transitionEventStatus({
+    supabase: svc, tenantId: 't1', eventId: 'e1', toStatus: 'arrived',
+    actor: { id: 'd1', type: 'human', context: { source: 'driver_app' } },
+  });
+  assert.equal(fireCalls.length, 1, 'expected one trigger fire');
+  assert.equal(fireCalls[0].eventType, 'pull');
+  assert.equal(fireCalls[0].timestampField, 'arrived_at');
+  assert.equal(fireCalls[0].loadId, 'o1');
+});
+
+test('transitionEventStatus arrived → departed fires departed trigger', async () => {
+  fireCalls.length = 0;
+  const svc = makeMockClient({
+    event: {
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'deliver', event_status: 'arrived',
+      arrived_at: '2026-04-24T12:00:00Z', departed_at: null,
+    },
+  });
+  await transitionEventStatus({
+    supabase: svc, tenantId: 't1', eventId: 'e1', toStatus: 'departed',
+    actor: { type: 'human' },
+  });
+  assert.equal(fireCalls.length, 1);
+  assert.equal(fireCalls[0].timestampField, 'departed_at');
+});
+
+test('transitionEventStatus pending → skipped does NOT fire trigger (no timestamp)', async () => {
+  fireCalls.length = 0;
+  const svc = makeMockClient({
+    event: {
+      id: 'e1', tenant_id: 't1', order_id: 'o1',
+      event_type: 'stop_off', event_status: 'pending',
+      arrived_at: null, departed_at: null,
+    },
+  });
+  await transitionEventStatus({
+    supabase: svc, tenantId: 't1', eventId: 'e1', toStatus: 'skipped',
+    actor: { type: 'human' },
+  });
+  assert.equal(fireCalls.length, 0, 'skip does not fire triggers');
+});

--- a/tests/geolocation-watcher-cadence.test.mjs
+++ b/tests/geolocation-watcher-cadence.test.mjs
@@ -1,0 +1,44 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { pickInterval } from '../lib/driver-app/geolocation-watcher.js';
+
+test('pickInterval first ping → moving (60s)', () => {
+  assert.equal(
+    pickInterval({ lastPing: null, currentPing: { latitude: 37.1, longitude: -122.5 }, onSite: false }),
+    60_000,
+  );
+});
+
+test('pickInterval movement >100m → moving (60s)', () => {
+  // ~111m east at lat=37
+  assert.equal(
+    pickInterval({
+      lastPing: { latitude: 37.1, longitude: -122.5 },
+      currentPing: { latitude: 37.1, longitude: -122.4988 },
+      onSite: false,
+    }),
+    60_000,
+  );
+});
+
+test('pickInterval movement <100m → stationary (180s)', () => {
+  assert.equal(
+    pickInterval({
+      lastPing: { latitude: 37.1, longitude: -122.5 },
+      currentPing: { latitude: 37.10001, longitude: -122.50001 },
+      onSite: false,
+    }),
+    180_000,
+  );
+});
+
+test('pickInterval onSite → 300s regardless of movement', () => {
+  assert.equal(
+    pickInterval({
+      lastPing: { latitude: 37.1, longitude: -122.5 },
+      currentPing: { latitude: 37.2, longitude: -122.5 },
+      onSite: true,
+    }),
+    300_000,
+  );
+});

--- a/tests/google-maps-server-distance.test.mjs
+++ b/tests/google-maps-server-distance.test.mjs
@@ -1,0 +1,71 @@
+// tests/google-maps-server-distance.test.mjs
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  buildCacheKey,
+  recomputeETA,
+  __resetCacheForTesting,
+} from '../lib/google-maps/server-distance.js';
+
+test('buildCacheKey rounds lat/lng to 3 decimals (~111m grid)', () => {
+  const k = buildCacheKey({
+    origin: { lat: 37.123456, lng: -122.987654 },
+    destination: { lat: 37.555111, lng: -122.444222, eventId: 'evt-1' },
+  });
+  assert.equal(k, '37.123,-122.988|37.555,-122.444|evt-1');
+});
+
+test('buildCacheKey same key for tiny lat/lng deltas', () => {
+  // Plan-as-written used inputs (37.1234 / 37.1238) that straddle the
+  // 3-decimal rounding boundary at .1235, producing DIFFERENT keys and
+  // contradicting the test name. Adjusted to inputs that genuinely
+  // round to the same 3-decimal grid (the test's intent).
+  const k1 = buildCacheKey({
+    origin: { lat: 37.1231, lng: -122.9878 },
+    destination: { lat: 37.5552, lng: -122.4443, eventId: 'evt-1' },
+  });
+  const k2 = buildCacheKey({
+    origin: { lat: 37.1233, lng: -122.9876 },
+    destination: { lat: 37.5554, lng: -122.4441, eventId: 'evt-1' },
+  });
+  assert.equal(k1, k2);
+});
+
+test('recomputeETA rejects when recomputeCount >= 50', async () => {
+  __resetCacheForTesting();
+  const result = await recomputeETA({
+    origin: { lat: 37.1, lng: -122.5 },
+    destination: { lat: 37.5, lng: -122.4, eventId: 'evt-1' },
+    recomputeCount: 50,
+  });
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, 'cost_cap_reached');
+});
+
+test('recomputeETA returns cached on second call within TTL', async () => {
+  __resetCacheForTesting();
+  let fetchCount = 0;
+  const mockFetch = async () => {
+    fetchCount++;
+    return {
+      ok: true,
+      json: async () => ({
+        rows: [{ elements: [{ status: 'OK', duration_in_traffic: { value: 1800 }, distance: { value: 16093 } }] }],
+      }),
+    };
+  };
+  const args = {
+    origin: { lat: 37.1, lng: -122.5 },
+    destination: { lat: 37.5, lng: -122.4, eventId: 'evt-1' },
+    recomputeCount: 0,
+    apiKey: 'test-key',
+    fetchImpl: mockFetch,
+  };
+  const r1 = await recomputeETA(args);
+  const r2 = await recomputeETA(args);
+  assert.equal(fetchCount, 1, 'second call hits cache');
+  assert.equal(r1.cached, false);
+  assert.equal(r2.cached, true);
+  assert.ok(r1.eta_arrival_at);
+  assert.equal(r1.distance_remaining_miles, 10);  // 16093m / 1609.344 ≈ 10
+});

--- a/tests/stale-ping-pause-cron.test.mjs
+++ b/tests/stale-ping-pause-cron.test.mjs
@@ -1,0 +1,20 @@
+// tests/stale-ping-pause-cron.test.mjs
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { findStaleMoves, STALE_THRESHOLD_MS } from '../lib/cron/stale-ping-pause.js';
+
+test('STALE_THRESHOLD_MS is 10 minutes', () => {
+  assert.equal(STALE_THRESHOLD_MS, 10 * 60 * 1000);
+});
+
+test('findStaleMoves returns moves older than threshold', () => {
+  const now = Date.now();
+  const moves = [
+    { id: 'a', tracking_status: 'in_transit', last_ping_at: new Date(now - 11 * 60 * 1000).toISOString() }, // stale
+    { id: 'b', tracking_status: 'in_transit', last_ping_at: new Date(now - 5 * 60 * 1000).toISOString() },  // fresh
+    { id: 'c', tracking_status: 'on_site', last_ping_at: new Date(now - 30 * 60 * 1000).toISOString() },    // on_site, ignored
+    { id: 'd', tracking_status: 'in_transit', last_ping_at: null },                                          // no ping yet, ignored
+  ];
+  const stale = findStaleMoves(moves, now);
+  assert.deepEqual(stale.map((m) => m.id), ['a']);
+});

--- a/tests/tracking-session-transition.test.mjs
+++ b/tests/tracking-session-transition.test.mjs
@@ -1,0 +1,117 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  isValidTrackingTransition,
+  getAllowedNextTrackingStatuses,
+  transitionTrackingSession,
+} from '../lib/routing/tracking-session-transition.js';
+
+function makeMockClient(config = {}) {
+  const calls = { selected: [], updated: [], inserted: [] };
+  function chain(table) {
+    const c = {
+      _table: table, _payload: null,
+      select() { return c; },
+      update(p) { c._payload = p; return c; },
+      insert(p) {
+        calls.inserted.push({ table: c._table, payload: p });
+        return Promise.resolve(config.insert ?? { data: null, error: null });
+      },
+      eq() { return c; },
+      async maybeSingle() {
+        calls.selected.push({ table: c._table });
+        return config.fetch ?? { data: null, error: null };
+      },
+      single() {
+        if (c._payload != null) {
+          calls.updated.push({ table: c._table, payload: c._payload });
+          return Promise.resolve(config.update ?? { data: { ...c._payload, id: 'm1' }, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+    };
+    return c;
+  }
+  return { from: (t) => chain(t), __calls: calls };
+}
+
+test('isValidTrackingTransition allows idle → in_transit', () => {
+  assert.equal(isValidTrackingTransition('idle', 'in_transit'), true);
+});
+
+test('isValidTrackingTransition rejects idle → on_site (must go through in_transit)', () => {
+  assert.equal(isValidTrackingTransition('idle', 'on_site'), false);
+});
+
+test('getAllowedNextTrackingStatuses for completed returns []', () => {
+  assert.deepEqual(getAllowedNextTrackingStatuses('completed'), []);
+});
+
+test('transitionTrackingSession throws when actor is missing', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'idle' }, error: null } });
+  await assert.rejects(
+    transitionTrackingSession({ supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'in_transit' }),
+    /actor is required/,
+  );
+});
+
+test('transitionTrackingSession throws when actor.type missing', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'idle' }, error: null } });
+  await assert.rejects(
+    transitionTrackingSession({
+      supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'in_transit',
+      actor: { id: 'd1' },
+    }),
+    /actor\.type is required/,
+  );
+});
+
+test('transitionTrackingSession idle → in_transit sets session_started_at', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'idle' }, error: null } });
+  await transitionTrackingSession({
+    supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'in_transit',
+    actor: { id: 'd1', type: 'human' },
+  });
+  const upd = svc.__calls.updated.find((u) => u.table === 'order_container_moves');
+  assert.ok(upd, 'expected an update on order_container_moves');
+  assert.equal(upd.payload.tracking_status, 'in_transit');
+  assert.ok(upd.payload.session_started_at, 'should set session_started_at on first transition out of idle');
+});
+
+test('transitionTrackingSession on_site → completed sets session_ended_at', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'on_site' }, error: null } });
+  await transitionTrackingSession({
+    supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'completed',
+    actor: { id: 'd1', type: 'human' },
+  });
+  const upd = svc.__calls.updated.find((u) => u.table === 'order_container_moves');
+  assert.equal(upd.payload.tracking_status, 'completed');
+  assert.ok(upd.payload.session_ended_at);
+});
+
+test('transitionTrackingSession writes history row with actor_type', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'idle' }, error: null } });
+  await transitionTrackingSession({
+    supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'in_transit',
+    actor: { id: 'd1', type: 'human', context: { source: 'driver_app', ping_id: 'p1' } },
+    note: 'started by driver',
+  });
+  const hist = svc.__calls.inserted.find((i) => i.table === 'move_tracking_session_history');
+  assert.ok(hist, 'expected history insert');
+  assert.equal(hist.payload.from_status, 'idle');
+  assert.equal(hist.payload.to_status, 'in_transit');
+  assert.equal(hist.payload.actor_type, 'human');
+  assert.equal(hist.payload.actor_id, 'd1');
+  assert.deepEqual(hist.payload.actor_context, { source: 'driver_app', ping_id: 'p1' });
+});
+
+test('transitionTrackingSession rejects invalid transitions', async () => {
+  const svc = makeMockClient({ fetch: { data: { tracking_status: 'completed' }, error: null } });
+  await assert.rejects(
+    transitionTrackingSession({
+      supabase: svc, tenantId: 't1', moveId: 'm1', toStatus: 'in_transit',
+      actor: { id: 'd1', type: 'human' },
+    }),
+    /Invalid transition: completed -> in_transit/,
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/evaluate-triggers",
+      "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/stale-ping-pause",
+      "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/breadcrumb-retention",
+      "schedule": "0 4 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Driver mobile move-tracking with live ETA + on-site duration** — driver web stub at `/driver/*` lets drivers tap Start / I'm here / Leaving from their phone; dispatcher sees live ETAs on planner cards and breadcrumb maps on Load Detail.
- **7 PRs bundled** (Tasks 1-43 from `docs/superpowers/plans/2026-04-24-driver-move-tracking.md`): foundation schema + helpers (PR 1), driver auth (PR 2), driver action endpoints + web stub (PR 3), MoveCell ETA + planner Realtime (PR 4), Tracking tab on Load Detail (PR 5), EventRow override + driver-modal toggle (PR 6), tenant settings tile + crons (PR 7).
- **Resolves FU-085** (this feature) and **FU-080** (transitionEventStatus now fires fireRoutingEventTriggers — driver-tap and dispatcher-edit paths both reliably fire dispatcher email triggers).
- **Reconciles with shipped infrastructure** — extends `driver_location_pings` from migration 036 (which had been laid as ELD-integration scaffolding but never applied to live DB until this PR). No parallel ping table.
- **138/138 unit tests green.** 14 new test files. Zero regressions.

## Migration order (REQUIRED before merge)

1. Apply `supabase/migrations/036_driver_tracking.sql` to live Supabase (was committed long ago but never applied — idempotent, safe to apply now).
2. Apply `supabase/migrations/102_driver_move_tracking.sql` (extends `driver_location_pings` with `move_id`+`battery_pct`, adds tracking-session state + ETA cache + auth + consent columns + history table + login attempts table + feature flag row).

## New env vars (set before deploy)

- `DRIVER_JWT_SECRET` — generate via `node -e \"console.log(require('crypto').randomBytes(64).toString('base64'))\"`
- `GOOGLE_MAPS_SERVER_API_KEY` — separate from `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`; create new Google Cloud key with Distance Matrix API enabled, server-side (no domain restriction needed)
- `CRON_SECRET` — already in use for `evaluate-triggers`; reused for new `stale-ping-pause` and `breadcrumb-retention` crons

## Architecture highlights

- **Two coupled state machines:** per-event \`event_status\` (pending→arrived→departed) shipped via B.1e foundation; per-move \`tracking_status\` (idle→in_transit→on_site→paused→completed) added here.
- **Composite atomic helper** \`lib/routing/driver-action.js\` orchestrates ping insert + event_status transition + tracking_status transition for every driver tap.
- **Three-gate authorization** on every ping/action: tenant feature flag + per-driver toggle + valid consent.
- **Server-side Distance Matrix** integration with 60s LRU cache + 90s recompute throttle + 50-per-move cost cap.
- **Realtime payload pre-filter** in \`useDriverPlanner.js\` — tracking-only column changes dispatch a targeted reducer action without full refetch.
- **Dispatcher override flow** preserves driver's original tap timestamp + GPS distance + ping_id in audit while letting dispatcher correct the timestamp.
- **IndexedDB offline queue** on driver app — buffers pings during connectivity loss, flushes on reconnect.

## Code-review fixes already incorporated

- **PING_CAP 40 → 500** (review caught: 40 was below realistic 8hr × 60s shifts = ~480 pings)
- **\`location_tracking_enabled\` toggle nesting bug** — initial implementation wrote to mobile_permissions JSONB but middleware reads top-level column; fixup commit corrects
- **JSDoc + missing forgotten-arrival test** on \`transitionEventStatus\` (FU-080 coverage gap)
- **\`feature_flags.is_active\` not \`default_enabled\`** — column-name mismatch caught and fixed mid-execution
- **\`tenant_feature_flags\` 3-column unique constraint** — implementer caught \`(tenant_id, feature_flag_id, user_id)\` and corrected upsert

## Test plan

- [ ] Migrations 036 + 102 applied to live Supabase, columns/tables/indexes confirmed in dashboard
- [ ] \`DRIVER_JWT_SECRET\` + \`GOOGLE_MAPS_SERVER_API_KEY\` set in production env (Vercel)
- [ ] \`npm run dev\` boots without missing-env errors
- [ ] Tenant admin: Settings → Drivers → Move Tracking toggle works (off → on, persists)
- [ ] Dispatcher: edit any driver → Mobile Permissions tab → Reset password → grab temp pwd from alert
- [ ] Driver login at \`/driver/login\` with username + temp pwd → forced to change-password → re-login with new pwd → \`/driver\` home shows today's moves
- [ ] Tap into a move → consent screen appears → Accept → Start move button visible
- [ ] Tap Start move → GPS prompt → tracking_status flips, ping scheduler starts
- [ ] Open Driver Planner in another tab → MoveCell shows live ETA without manual refresh (Realtime working)
- [ ] Tap I'm here → on-site mm:ss counter ticks live on dispatcher MoveCell
- [ ] Tap Leaving → ETA flips back to next event
- [ ] Open Load Detail → Tracking tab → Live Tracking section shows breadcrumb polyline + activity log
- [ ] On EventRow timestamps: 📱 driver badge appears, click opens override modal, save updates with 🔄 override badge + audit trail preserved
- [ ] Stop driver app for 11 minutes → cron flips move to paused → MoveCell goes amber
- [ ] Resume driver app → first ping flips back to in_transit
- [ ] **Legal review** of consent text at \`lib/driver-consent/text.js\` before merging to prod (file carries \`// LEGAL REVIEW REQUIRED BEFORE PROD\` flag)
- [ ] Resolve FU-085 + FU-080 in \`memory/followups.md\` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)